### PR TITLE
Support touch events for the range slider.

### DIFF
--- a/src/js/components/RangeSlider/RangeSlider.jsx
+++ b/src/js/components/RangeSlider/RangeSlider.jsx
@@ -48,6 +48,8 @@ export const RangeSlider = ({
             onChange={(event) => debouncedHandleChange(parseFloat(event.target.value))}
             onMouseDown={handleMouseDown}
             onMouseUp={handleMouseUp}
+            onTouchStart={handleMouseDown}
+            onTouchEnd={handleMouseUp}
             tabIndex={-1}
           />
         )}


### PR DESCRIPTION
Simply reuse the same handlers as for the mouse.

I use Chromatix as a dedicated full screen media player on raspberry Pis
with a touchscreen for my kids, and not being able to skip back and forward
for audiobooks/stories can be frustrating.

This has been the only complaint so far :)
