### PR TITLE
#18 - Identify OS/hostname to plex when running electron

### DIFF
--- a/src/js/services/plexTools.js
+++ b/src/js/services/plexTools.js
@@ -5,8 +5,10 @@
 import axios from 'axios';
 
 import config from 'js/_config/config';
-import { getBrowserName, getLocalStorage, raceToSuccess, setLocalStorage } from 'js/utils';
+import { getLocalStorage, raceToSuccess, setLocalStorage } from 'js/utils';
 import * as plexTranspose from 'js/services/plexTranspose';
+import getPlayerPlatformName from 'js/utils/getPlayerPlatformName';
+import getPlayerDeviceName from 'js/utils/getPlayerDeviceName';
 
 // ======================================================================
 // OPTIONS
@@ -1430,7 +1432,6 @@ export const setStarRating = ({ accessToken, rating, ratingKey, serverBaseUrl, s
   return new Promise((resolve, reject) => {
     try {
       const endpoint = endpointConfig.rating.setStarRating(serverBaseUrl, ratingKey, rating);
-      const browserName = getBrowserName();
       const params = {
         identifier: 'com.plexapp.plugins.library',
         key: ratingKey,
@@ -1447,8 +1448,8 @@ export const setStarRating = ({ accessToken, rating, ratingKey, serverBaseUrl, s
             'X-Plex-Client-Identifier': clientId,
             'X-Plex-Session-Identifier': sessionId,
             'X-Plex-Product': appName,
-            'X-Plex-Device-Name': browserName,
-            'X-Plex-Platform': browserName,
+            'X-Plex-Device-Name': getPlayerDeviceName(),
+            'X-Plex-Platform': getPlayerPlatformName(),
             'X-Plex-Device-Icon': clientIcon,
           },
         })
@@ -1491,7 +1492,6 @@ export const logPlaybackStatus = ({
   return new Promise((resolve, reject) => {
     try {
       const endpoint = endpointConfig.status.logPlaybackStatus(serverBaseUrl);
-      const browserName = getBrowserName();
       const params = {
         type: type,
         key: trackId,
@@ -1546,8 +1546,8 @@ export const logPlaybackStatus = ({
             'X-Plex-Client-Identifier': clientId,
             'X-Plex-Session-Identifier': sessionId,
             'X-Plex-Product': appName,
-            'X-Plex-Device-Name': browserName,
-            'X-Plex-Platform': browserName,
+            'X-Plex-Device-Name': getPlayerDeviceName(),
+            'X-Plex-Platform': getPlayerPlatformName(),
             'X-Plex-Device-Icon': clientIcon,
           },
         })
@@ -1590,7 +1590,6 @@ export const logPlaybackQuit = ({
 }) => {
   try {
     const endpoint = endpointConfig.status.logPlaybackStatus(serverBaseUrl);
-    const browserName = getBrowserName();
     const params = new URLSearchParams({
       type: type,
       key: trackId,
@@ -1612,8 +1611,8 @@ export const logPlaybackQuit = ({
         'X-Plex-Client-Identifier': clientId,
         'X-Plex-Session-Identifier': sessionId,
         'X-Plex-Product': appName,
-        'X-Plex-Device-Name': browserName,
-        'X-Plex-Platform': browserName,
+        'X-Plex-Device-Name': getPlayerDeviceName(),
+        'X-Plex-Platform': getPlayerPlatformName(),
         'X-Plex-Device-Icon': clientIcon,
       },
     });

--- a/src/js/utils/getPlayerDeviceName.ts
+++ b/src/js/utils/getPlayerDeviceName.ts
@@ -1,0 +1,21 @@
+import { isElectron } from './environment';
+import os from 'os';
+import getBrowserName from './getBrowserName';
+
+/**
+ * Gets an appropriate device name to provide to the media provider
+ * @returns The detected platform name or 'Unknown'
+ */
+const getPlayerDeviceName = (): string => {
+  let deviceName;
+
+  if (isElectron) {
+    deviceName = os.hostname();
+  } else {
+    deviceName = getBrowserName();
+  }
+
+  return deviceName ?? 'Unknown';
+};
+
+export default getPlayerDeviceName;

--- a/src/js/utils/getPlayerDeviceName.ts
+++ b/src/js/utils/getPlayerDeviceName.ts
@@ -4,7 +4,7 @@ import getBrowserName from './getBrowserName';
 
 /**
  * Gets an appropriate device name to provide to the media provider
- * @returns The detected platform name or 'Unknown'
+ * @returns The detected device name or 'Unknown'
  */
 const getPlayerDeviceName = (): string => {
   let deviceName;

--- a/src/js/utils/getPlayerPlatformName.ts
+++ b/src/js/utils/getPlayerPlatformName.ts
@@ -1,0 +1,21 @@
+import { isElectron } from './environment';
+import getBrowserName from './getBrowserName';
+import getOperatingSystemName from './getOperatingSystemName';
+
+/**
+ * Gets an appropriate platform name to provide to the media provider based on whether the user is using the Electron version or not
+ * @returns The detected platform name or 'Unknown'
+ */
+const getPlayerPlatformName = (): string => {
+  let platformName;
+
+  if (isElectron) {
+    platformName = getOperatingSystemName();
+  } else {
+    platformName = getBrowserName();
+  }
+
+  return platformName ?? 'Unknown';
+};
+
+export default getPlayerPlatformName;


### PR DESCRIPTION
Adds what I mentioned in #18 

Adds some logic to retrieve platform name/hostname when fetching data for the Plex headers. This should give a more user-expected value when playing from the electron version. I've tried to emulate how the Plex Web App does it compared to the MS store one with what values it provides.

Hostname was preferred to computer name as grabbing that on Mac/Linux requires some CLI bits which just look a bit nefarious. Hostname makes more sense too as that's how it appears on the network.

Jellyfin was deliberately left out as I'm not sure what the appropriate values are as I don't have an instance of it running to determine a valid value, but the functions were left deliberately platform-agnostic so that it can be used for any.