### PR TITLE
Add StarRating to ControlBar

### DIFF
--- a/src/js/components/ControlBar/ControlBar.jsx
+++ b/src/js/components/ControlBar/ControlBar.jsx
@@ -7,7 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { NavLink } from 'react-router-dom';
 import clsx from 'clsx';
 
-import { Icon, PopoverMenu, RangeSlider } from 'js/components';
+import { Icon, PopoverMenu, RangeSlider, StarRating } from 'js/components';
 import { useKeyMediaControls, useMediaControls, useMediaMeta, usePlayerProgress } from 'js/hooks';
 import { analyticsEvent, durationToStringShort } from 'js/utils';
 import platformFeatures from 'js/_config/platformFeatures';
@@ -73,17 +73,26 @@ const NowPlaying = () => {
       </div>
       <div className={style.text}>
         {trackCurrent && (
-          <>
-            <div className={style.title}>{trackCurrent.title}</div>
-            <div className={style.artist}>
-              {trackCurrent.artistLink && (
-                <NavLink to={trackCurrent.artistLink} draggable="false">
-                  {trackCurrent.artist}
-                </NavLink>
-              )}
-              {!trackCurrent.artistLink && trackCurrent.artist}
+          <div className={style.trackCurrent}>
+            <div>
+              <div className={style.title}>{trackCurrent.title}</div>
+              <div className={style.artist}>
+                {trackCurrent.artistLink && (
+                  <NavLink to={trackCurrent.artistLink} draggable="false">
+                    {trackCurrent.artist}
+                  </NavLink>
+                )}
+                {!trackCurrent.artistLink && trackCurrent.artist}
+              </div>
             </div>
-          </>
+            <StarRating
+              type="track"
+              ratingKey={trackCurrent.trackId}
+              rating={trackCurrent.userRating}
+              editable
+              size={14}
+            />
+          </div>
         )}
       </div>
     </div>

--- a/src/js/components/ControlBar/ControlBar.module.scss
+++ b/src/js/components/ControlBar/ControlBar.module.scss
@@ -47,6 +47,7 @@
     height: 56px;
     margin-right: 12px;
   }
+
   @media (min-width: 1024px) {
     width: 68px;
     height: 68px;
@@ -101,6 +102,12 @@
   @media (min-width: 1024px) {
     width: calc(100% - 75px);
   }
+}
+
+.trackCurrent {
+  display: flex;
+  align-items: center;
+  gap: 16px;
 }
 
 .title {
@@ -299,10 +306,12 @@ button.active {
   line-height: 1;
   color: var(--color-opacity-07);
 }
+
 .scrubLeft {
   margin-right: 8px;
   text-align: right;
 }
+
 .scrubRight {
   margin-left: 8px;
   text-align: left;


### PR DESCRIPTION
Adds the Star Rating to the Control Bar to let people easily rate their music right as it's playing, without having to be in fullscreen mode or having to click the track and rate it there.

This is a feature that I used regularly in PlexAmp and felt that it was missing from Chromatix.

I'm not sure if this looks good but it is where Spotify places their like/playlist button.
<img width="337" height="89" alt="image" src="https://github.com/user-attachments/assets/3187eb34-bfce-4b2d-92ef-cc3db4764b15" />