### PR TITLE
Add shuffle all tracks feature

### DIFF
--- a/src/js/pages/AlbumArray.jsx
+++ b/src/js/pages/AlbumArray.jsx
@@ -2,7 +2,7 @@
 // IMPORTS
 // ======================================================================
 
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import {
   FilterMenu,
@@ -22,6 +22,7 @@ import platformFeatures from 'js/_config/platformFeatures';
 // ======================================================================
 
 const AlbumArray = () => {
+  const dispatch = useDispatch();
   const currentService = useSelector(({ appModel }) => appModel.currentService);
   const platformOpts = platformFeatures[currentService] || {};
 
@@ -40,6 +41,11 @@ const AlbumArray = () => {
     sortedAlbums,
   } = useGetAlbumArray();
 
+  // Handler for Play/Shuffle All buttons
+  const handlePlayAll = (isShuffle) => {
+    dispatch.playerModel.playerLoadAllTracks({ isShuffle });
+  };
+
   const isLoading = !sortedAlbums;
   const isEmptyList = !isLoading && sortedAlbums?.length === 0;
   const isGridView = !isLoading && !isEmptyList && viewAlbums === 'grid';
@@ -51,6 +57,7 @@ const AlbumArray = () => {
         <Title
           colOptions={colOptions}
           gridOptions={gridOptions}
+          handlePlayAll={handlePlayAll}
           isGridView={isGridView}
           isListView={isListView}
           orderAlbums={orderAlbums}
@@ -75,6 +82,7 @@ const AlbumArray = () => {
           <Title
             colOptions={colOptions}
             gridOptions={gridOptions}
+            handlePlayAll={handlePlayAll}
             isGridView={isGridView}
             isListView={isListView}
             orderAlbums={orderAlbums}
@@ -100,6 +108,7 @@ const AlbumArray = () => {
           <Title
             colOptions={colOptions}
             gridOptions={gridOptions}
+            handlePlayAll={handlePlayAll}
             isGridView={isGridView}
             isListView={isListView}
             orderAlbums={orderAlbums}
@@ -121,6 +130,7 @@ const AlbumArray = () => {
 const Title = ({
   colOptions,
   gridOptions,
+  handlePlayAll,
   isGridView,
   isListView,
   orderAlbums,
@@ -142,6 +152,8 @@ const Title = ({
           sortedAlbums ? sortedAlbums?.length + ' Album' + (sortedAlbums?.length !== 1 ? 's' : '') : <>&nbsp;</>
         }
         padding={!isListView && !isGridView}
+        showPlay={true}
+        handlePlay={handlePlayAll}
       />
       <FilterWrap padding={!isListView && !isGridView}>
         <FilterToggle

--- a/src/js/services/bridge.js
+++ b/src/js/services/bridge.js
@@ -774,6 +774,36 @@ export const getAlbumTracks = (libraryId, albumId) => {
 };
 
 // ======================================================================
+// GET ALL TRACKS
+// ======================================================================
+
+export const getAllTracks = (libraryId) => {
+  return new Promise((resolve, reject) => {
+    console.log('%c--- bridge - getAllTracks ---', 'color:#f9743b;');
+    const accessToken = store.getState().sessionModel.currentServer.accessToken;
+    const currentService = store.getState().appModel.currentService;
+    const serverBaseUrl = store.getState().appModel.serverBaseUrl;
+    const userId = currentService === 'jellyfin' ? store.getState().appModel.currentUser.userId : null;
+
+    serviceTools[currentService]
+      .getAllTracks({
+        accessToken,
+        libraryId,
+        serverBaseUrl,
+        userId,
+      })
+      .then((response) => {
+        resolve(response);
+      })
+      .catch((error) => {
+        console.error(error);
+        analyticsEvent(toUpperFirst(currentService) + ' / Error / Get All Tracks');
+        reject(error);
+      });
+  });
+};
+
+// ======================================================================
 // GET FOLDER ITEMS
 // ======================================================================
 

--- a/src/js/services/jellyTools.js
+++ b/src/js/services/jellyTools.js
@@ -58,6 +58,9 @@ const endpointConfig = {
     getAlbumDetails: (serverBaseUrl, albumId) => `${serverBaseUrl}/Items/${albumId}`,
     getAlbumTracks: (serverBaseUrl, userId) => `${serverBaseUrl}/Users/${userId}/Items`,
   },
+  track: {
+    getAllTracks: (serverBaseUrl, userId) => `${serverBaseUrl}/Users/${userId}/Items`,
+  },
   folder: {
     getFolderItems: null,
   },
@@ -736,6 +739,52 @@ export const getAlbumTracks = ({ accessToken, albumId, libraryId, serverBaseUrl,
       reject({
         code: 'jellyfin.getAlbumTracks.2',
         message: 'Failed to get album tracks: ' + error?.message,
+        error: error,
+      });
+    }
+  });
+};
+
+// ======================================================================
+// GET ALL TRACKS
+// ======================================================================
+
+export const getAllTracks = ({ accessToken, libraryId, serverBaseUrl, userId }) => {
+  return new Promise((resolve, reject) => {
+    try {
+      const endpoint = endpointConfig.track.getAllTracks(serverBaseUrl, userId);
+      const controller = new AbortController();
+      abortControllers.push(controller);
+
+      axios
+        .get(endpoint, {
+          headers: getRequestHeaders(accessToken),
+          signal: controller.signal,
+          params: {
+            ParentId: libraryId,
+            IncludeItemTypes: 'Audio',
+            Recursive: true,
+            SortBy: 'Random',
+            Fields: trackFields,
+          },
+        })
+        .then((response) => {
+          resolve(jellyTranspose.transposeTrackArray(response, libraryId, serverBaseUrl, accessToken));
+        })
+        .catch((error) => {
+          reject({
+            code: 'jellyfin.getAllTracks.1',
+            message: 'Failed to get all tracks: ' + error?.message,
+            error: error,
+          });
+        })
+        .finally(() => {
+          abortControllers = abortControllers.filter((ctrl) => ctrl !== controller);
+        });
+    } catch (error) {
+      reject({
+        code: 'jellyfin.getAllTracks.2',
+        message: 'Failed to get all tracks: ' + error?.message,
         error: error,
       });
     }

--- a/src/js/services/plexTools.js
+++ b/src/js/services/plexTools.js
@@ -72,6 +72,9 @@ const endpointConfig = {
     getAlbumDetails: (serverBaseUrl, albumId) => `${serverBaseUrl}/library/metadata/${albumId}`,
     getAlbumTracks: (serverBaseUrl, albumId) => `${serverBaseUrl}/library/metadata/${albumId}/children`,
   },
+  track: {
+    getAllTracks: (serverBaseUrl, libraryId) => `${serverBaseUrl}/library/sections/${libraryId}/all`,
+  },
   folder: {
     getFolderItems: (serverBaseUrl, libraryId) => `${serverBaseUrl}/library/sections/${libraryId}/folder`,
   },
@@ -960,6 +963,51 @@ export const getAlbumTracks = ({ accessToken, albumId, libraryId, serverBaseUrl,
       reject({
         code: 'plex.getAlbumTracks.2',
         message: 'Failed to get album tracks: ' + error?.message,
+        error: error,
+      });
+    }
+  });
+};
+
+// ======================================================================
+// GET ALL TRACKS
+// ======================================================================
+
+export const getAllTracks = ({ accessToken, libraryId, serverBaseUrl }) => {
+  return new Promise((resolve, reject) => {
+    try {
+      const endpoint = endpointConfig.track.getAllTracks(serverBaseUrl, libraryId);
+      const controller = new AbortController();
+      abortControllers.push(controller);
+
+      axios
+        .get(endpoint, {
+          headers: getRequestHeaders(accessToken),
+          params: {
+            type: 10,
+            sort: 'random',
+            excludeFields: trackExcludeFields,
+            excludeElements: excludeElements,
+          },
+          signal: controller.signal,
+        })
+        .then((response) => {
+          resolve(plexTranspose.transposeTrackArray(response, libraryId, serverBaseUrl, accessToken));
+        })
+        .catch((error) => {
+          reject({
+            code: 'plex.getAllTracks.1',
+            message: 'Failed to get all tracks: ' + error?.message,
+            error: error,
+          });
+        })
+        .finally(() => {
+          abortControllers = abortControllers.filter((ctrl) => ctrl !== controller);
+        });
+    } catch (error) {
+      reject({
+        code: 'plex.getAllTracks.2',
+        message: 'Failed to get all tracks: ' + error?.message,
         error: error,
       });
     }

--- a/src/js/store/models.player.js
+++ b/src/js/store/models.player.js
@@ -441,6 +441,45 @@ const effects = (dispatch) => ({
     analyticsEvent(toUpperFirst(currentService) + ' / Music / Play (Folder)');
   },
 
+  async playerLoadAllTracks(payload, rootState) {
+    console.log('%c--- playerLoadAllTracks ---', 'color:#5c16b1');
+    const { isShuffle = true } = payload || {};
+
+    const currentService = rootState.appModel.currentService;
+    const libraryId = rootState.sessionModel.currentLibrary?.libraryId;
+
+    // Fetch all tracks from the library
+    const allTracks = await bridge.getAllTracks(libraryId);
+
+    if (!allTracks || allTracks.length === 0) {
+      console.error('No tracks found in library');
+      return;
+    }
+
+    // Generate track keys (shuffled or not)
+    const trackKeys = getTrackKeys(allTracks.length, null, isShuffle, null);
+
+    dispatch.playerModel.playerLoadTrackList({
+      playingVariant: 'all-tracks',
+      playingServerId: rootState.sessionModel.currentServer?.serverId,
+      playingLibraryId: libraryId,
+      playingArtistId: null,
+      playingAlbumId: null,
+      playingPlaylistId: null,
+      playingFolderId: null,
+      playingLink: `/library/${libraryId}`,
+      playingOrder: null,
+      playingTrackIndex: 0,
+      playingTrackKeys: trackKeys,
+      playingTrackList: allTracks,
+      playingTrackCount: allTracks.length,
+      playingTrackProgress: 0,
+      playingShuffle: isShuffle,
+    });
+
+    analyticsEvent(toUpperFirst(currentService) + ' / Music / Play (' + (isShuffle ? 'Shuffle All' : 'All') + ')');
+  },
+
   playerLoadTrackList(payload, rootState) {
     // console.log('%c--- playerLoadTrackList ---', 'color:#5c16b1');
     dispatch.playerModel.setPlayerState({


### PR DESCRIPTION
This commit adds a comprehensive "Shuffle All" feature that allows users to shuffle and play all tracks from their entire music collection.

Changes:
- Added getAllTracks() API function in jellyTools.js to fetch all tracks from Jellyfin library
- Added getAllTracks() API function in plexTools.js to fetch all tracks from Plex library
- Added bridge function getAllTracks() to handle service-agnostic track fetching
- Added playerLoadAllTracks() action to player model that fetches and plays all library tracks
- Added Play/Shuffle buttons to Albums page (AlbumArray.jsx) to trigger the new feature
- Supports both sequential play and shuffled play of entire collection
- Uses existing Fisher-Yates shuffle algorithm for randomization

The feature is accessible from the Albums page, where users can click:
- "Play" button to play all tracks in order
- "Shuffle" button to shuffle all tracks in the collection