### PR TITLE
Expand automated testing: core playback + transpose coverage, CI, Node 23+ fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [develop, staging, production]
+  pull_request:
+
+jobs:
+  checks:
+    name: Checks (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Oldest supported (engines >= 20), current LTS, and latest — the test
+        # environment is Node-version sensitive (see vitest.setup.ts).
+        node-version: [20.x, 22.x, 24.x]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Knip (unused code)
+        run: npm run knip
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Prettier
+        run: npm run prettier
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Unit tests
+        run: npm run test:all
+
+      - name: Build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Or run all checks at once (excluding tests) with:
 npm run check
 ```
 
+The same checks (plus the unit tests and a production build) also run automatically on GitHub Actions for every pull request and for pushes to `develop`, `staging` and `production` — see `.github/workflows/ci.yml`.
+
 # 8. Use of AI
 
 AI is an obviously common but controversial tool in software development right now. After years of building websites and web apps by hand, and over a year of building and maintaining Chromatix manually, I do now use [GitHub Copilot](https://github.com/features/copilot) and I want to be transparent about that.

--- a/src/js/services/__fixtures__/jellyfinApi.ts
+++ b/src/js/services/__fixtures__/jellyfinApi.ts
@@ -1,0 +1,278 @@
+// Generated using Claude Code
+
+// Raw Jellyfin API response payloads for use in tests, shaped exactly as the
+// axios responses ({ data: ... }) that jellyTools.js passes to jellyTranspose.js.
+// Field names and values mirror real Jellyfin 10.x server output; fields not
+// read by the transpose functions are included sparingly to prove they are ignored.
+
+// ======================================================================
+// USER — /Users/{userId}
+// ======================================================================
+
+export const JELLY_USER_RESPONSE = {
+  data: {
+    Name: 'demo-user',
+    ServerId: 'server-1',
+    Id: 'user-1',
+    PrimaryImageTag: 'usertag123',
+    HasPassword: true,
+  },
+};
+
+export const JELLY_USER_NO_IMAGE_RESPONSE = {
+  data: {
+    Name: 'imageless-user',
+    ServerId: 'server-1',
+    Id: 'user-2',
+    HasPassword: true,
+  },
+};
+
+// ======================================================================
+// SERVER — /System/Info
+// ======================================================================
+
+export const JELLY_SERVER_RESPONSE = {
+  data: {
+    Id: 'server-1',
+    ServerName: 'Home Media',
+    Version: '10.10.3',
+    OperatingSystem: 'Linux',
+    LocalAddress: 'http://192.168.1.20:8096',
+    StartupWizardCompleted: true,
+  },
+};
+
+export const JELLY_SERVER_UNNAMED_RESPONSE = {
+  data: {
+    Id: 'server-2',
+    Version: '10.10.3',
+  },
+};
+
+// ======================================================================
+// LIBRARIES — /Users/{userId}/Views
+// ======================================================================
+
+export const JELLY_LIBRARIES_RESPONSE = {
+  data: {
+    Items: [
+      { Id: 'library-1', Name: 'Music', CollectionType: 'music', Type: 'CollectionFolder' },
+      { Id: 'library-2', Name: 'Movies', CollectionType: 'movies', Type: 'CollectionFolder' },
+      { Id: 'library-3', Name: 'Playlists', CollectionType: 'playlists', Type: 'CollectionFolder' },
+    ],
+    TotalRecordCount: 3,
+    StartIndex: 0,
+  },
+};
+
+// ======================================================================
+// ARTISTS — /Artists, /Artists/AlbumArtists
+// ======================================================================
+
+// Has both a Primary image and a Backdrop — Primary must win.
+export const JELLY_ARTIST_PRIMARY = {
+  Id: 'artist-1',
+  Name: 'The Midnight Owls',
+  Type: 'MusicArtist',
+  Genres: ['Indie Rock', 'Shoegaze'],
+  UserData: { PlaybackPositionTicks: 0, PlayCount: 42, IsFavorite: true, Played: true },
+  ImageTags: { Primary: 'artistprimary1' },
+  BackdropImageTags: ['artistbackdrop1'],
+};
+
+// No Primary image — falls back to the first Backdrop; no UserData or Genres.
+export const JELLY_ARTIST_BACKDROP = {
+  Id: 'artist-2',
+  Name: 'Vera Lane',
+  Type: 'MusicArtist',
+  BackdropImageTags: ['artistbackdrop2'],
+};
+
+export const JELLY_ARTISTS_RESPONSE = {
+  data: {
+    Items: [JELLY_ARTIST_PRIMARY, JELLY_ARTIST_BACKDROP],
+    TotalRecordCount: 2,
+    StartIndex: 0,
+  },
+};
+
+// ======================================================================
+// ALBUMS — /Items?IncludeItemTypes=MusicAlbum
+// ======================================================================
+
+// AlbumArtists contains an entry matching AlbumArtist by name (second in the
+// list) — the matching entry must be picked over the first one.
+export const JELLY_ALBUM_MAIN = {
+  Id: 'album-1',
+  Name: 'Nocturnal Songs',
+  Type: 'MusicAlbum',
+  AlbumArtist: 'The Midnight Owls',
+  AlbumArtists: [
+    { Id: 'artist-2', Name: 'Vera Lane' },
+    { Id: 'artist-1', Name: 'The Midnight Owls' },
+  ],
+  Genres: ['Indie Rock'],
+  PremiereDate: '2019-03-15T00:00:00.0000000Z',
+  ProductionYear: 2019,
+  UserData: { PlaybackPositionTicks: 0, PlayCount: 7, IsFavorite: true, Played: true },
+  ImageTags: { Primary: 'albumprimary1' },
+};
+
+// AlbumArtist name matches none of the AlbumArtists entries — first entry wins.
+const JELLY_ALBUM_NO_MATCHING_ARTIST = {
+  Id: 'album-2',
+  Name: 'Various Hits',
+  Type: 'MusicAlbum',
+  AlbumArtist: 'Various Artists',
+  AlbumArtists: [{ Id: 'artist-3', Name: 'Nina Field' }],
+  ImageTags: { Primary: 'albumprimary2' },
+};
+
+// No AlbumArtists, UserData, or images at all.
+const JELLY_ALBUM_MINIMAL = {
+  Id: 'album-3',
+  Name: 'Demo Tapes',
+  Type: 'MusicAlbum',
+};
+
+export const JELLY_ALBUMS_RESPONSE = {
+  data: {
+    Items: [JELLY_ALBUM_MAIN, JELLY_ALBUM_NO_MATCHING_ARTIST, JELLY_ALBUM_MINIMAL],
+    TotalRecordCount: 3,
+    StartIndex: 0,
+  },
+};
+
+// ======================================================================
+// PLAYLISTS — /Users/{userId}/Items?IncludeItemTypes=Playlist
+// ======================================================================
+
+export const JELLY_PLAYLIST_MAIN = {
+  Id: 'playlist-1',
+  Name: 'Late Night Drive',
+  Type: 'Playlist',
+  ChildCount: 24,
+  RunTimeTicks: 54000000000,
+  UserData: { PlaybackPositionTicks: 0, PlayCount: 3, IsFavorite: true, Played: false },
+  ImageTags: { Primary: 'playlistprimary1' },
+};
+
+export const JELLY_PLAYLISTS_RESPONSE = {
+  data: {
+    Items: [JELLY_PLAYLIST_MAIN],
+    TotalRecordCount: 1,
+    StartIndex: 0,
+  },
+};
+
+// ======================================================================
+// TRACKS — /Users/{userId}/Items?IncludeItemTypes=Audio
+// ======================================================================
+
+// A fully-populated track. The EmbeddedImage stream is listed first to prove
+// the transpose picks the stream with Type 'Audio', not simply the first one.
+// AlbumArtists contains the matching artist second so name matching (not
+// first-entry fallback) is exercised. Has both its own Primary image and an
+// AlbumPrimaryImageTag — its own Primary must win.
+export const JELLY_TRACK_FLAC = {
+  Id: 'track-1',
+  Name: 'City Lights',
+  Type: 'Audio',
+  Album: 'Nocturnal Songs',
+  AlbumId: 'album-1',
+  AlbumArtist: 'The Midnight Owls',
+  AlbumArtists: [
+    { Id: 'artist-2', Name: 'Vera Lane' },
+    { Id: 'artist-1', Name: 'The Midnight Owls' },
+  ],
+  AlbumPrimaryImageTag: 'albumprimary1',
+  ImageTags: { Primary: 'trackprimary1' },
+  IndexNumber: 3,
+  ParentIndexNumber: 1,
+  PlaylistItemId: 'playlistitem-77',
+  PremiereDate: '2019-03-15T00:00:00.0000000Z',
+  RunTimeTicks: 2160000000,
+  UserData: { PlaybackPositionTicks: 0, PlayCount: 12, IsFavorite: true, Played: true },
+  MediaStreams: [
+    { Codec: 'mjpeg', Type: 'EmbeddedImage', Index: 1 },
+    { Codec: 'flac', Type: 'Audio', Index: 0, BitRate: 1411213, SampleRate: 44100, Channels: 2, BitDepth: 16 },
+  ],
+};
+
+// Windows Media Audio track — raw codec 'wmav2'; BitRate rounds up to 193 kbps.
+export const JELLY_TRACK_WMA = {
+  Id: 'track-2',
+  Name: 'Old Archive',
+  Type: 'Audio',
+  Album: 'Various Hits',
+  AlbumId: 'album-2',
+  AlbumArtist: 'Various Artists',
+  AlbumArtists: [{ Id: 'artist-3', Name: 'Nina Field' }],
+  IndexNumber: 1,
+  ParentIndexNumber: 1,
+  RunTimeTicks: 1800000000,
+  UserData: { PlaybackPositionTicks: 0, PlayCount: 0, IsFavorite: false, Played: false },
+  MediaStreams: [{ Codec: 'wmav2', Type: 'Audio', Index: 0, BitRate: 192500, SampleRate: 44100, Channels: 2 }],
+};
+
+// A track with the bare minimum of fields — no album, artists, images,
+// media streams, user data, or runtime.
+export const JELLY_TRACK_MINIMAL = {
+  Id: 'track-3',
+  Name: 'Untitled',
+  Type: 'Audio',
+};
+
+// No own images — thumb falls back to the album's Primary image (AlbumId + AlbumPrimaryImageTag).
+export const JELLY_TRACK_ALBUM_ART = {
+  Id: 'track-4',
+  Name: 'Harbour',
+  Type: 'Audio',
+  AlbumId: 'album-1',
+  AlbumPrimaryImageTag: 'albumprimary1',
+};
+
+// No Primary images anywhere — thumb falls back to the track's own first Backdrop.
+export const JELLY_TRACK_BACKDROP = {
+  Id: 'track-5',
+  Name: 'Overcast',
+  Type: 'Audio',
+  AlbumId: 'album-1',
+  BackdropImageTags: ['trackbackdrop5'],
+};
+
+// No images on the track itself — thumb falls back to the album's first Backdrop
+// (AlbumId + ParentBackdropImageTags).
+export const JELLY_TRACK_PARENT_BACKDROP = {
+  Id: 'track-6',
+  Name: 'Seaglass',
+  Type: 'Audio',
+  AlbumId: 'album-1',
+  ParentBackdropImageTags: ['parentbackdrop1'],
+};
+
+// ======================================================================
+// SEARCH — /Items?searchTerm=...
+// ======================================================================
+
+// Deliberately out of order, with two entries per sortable dimension:
+// results must be sorted by type (artist, album, playlist, track) and then
+// by title within a type. The 'Genre' entry is an unsupported type and must
+// be dropped. 'Alpine Air' has both ParentId and AlbumId (ParentId wins);
+// 'Zebra Crossing' has only AlbumId (fallback).
+export const JELLY_SEARCH_RESPONSE = {
+  data: {
+    Items: [
+      { Id: 'track-20', Name: 'Zebra Crossing', Type: 'Audio', AlbumId: 'album-20' },
+      { Id: 'artist-21', Name: 'Beta Waves', Type: 'MusicArtist', ImageTags: { Primary: 'searchartist21' } },
+      { Id: 'playlist-22', Name: 'Morning Mix', Type: 'Playlist' },
+      { Id: 'track-23', Name: 'Alpine Air', Type: 'Audio', ParentId: 'album-23', AlbumId: 'album-99' },
+      { Id: 'album-24', Name: 'Basement Sessions', Type: 'MusicAlbum' },
+      { Id: 'artist-25', Name: 'Alpha Court', Type: 'MusicArtist' },
+      { Id: 'genre-26', Name: 'Ambient', Type: 'Genre' },
+    ],
+    TotalRecordCount: 7,
+    StartIndex: 0,
+  },
+};

--- a/src/js/services/__fixtures__/plexResponses.ts
+++ b/src/js/services/__fixtures__/plexResponses.ts
@@ -1,0 +1,667 @@
+// Generated using Claude Code
+
+// Raw Plex API response payloads for use in tests.
+// Each constant is shaped like the axios response the transpose functions
+// receive ({ data: ... }), mirroring what the (undocumented) Plex API
+// returns, trimmed to the fields Chromatix actually reads.
+
+// ======================================================================
+// SHARED METADATA ENTRIES
+// ======================================================================
+
+const albumElectricNights = {
+  ratingKey: '200',
+  key: '/library/metadata/200/children',
+  type: 'album',
+  title: 'Electric Nights',
+  parentTitle: 'The Static Charms',
+  parentRatingKey: '100',
+  Genre: [{ tag: 'Electronic' }, { tag: 'Synthpop' }],
+  addedAt: 1700000001,
+  lastViewedAt: 1712000001,
+  userRating: 9,
+  originallyAvailableAt: '2020-05-15',
+  thumb: '/library/metadata/200/thumb/1712345678',
+};
+
+const albumCompilation = {
+  ratingKey: '201',
+  key: '/library/metadata/201/children',
+  type: 'album',
+  title: 'Compilation Vol. 1',
+  parentTitle: 'Various Artists',
+  parentRatingKey: '101',
+  addedAt: 1690000000,
+};
+
+const albumLiveAtTheRoundhouse = {
+  ratingKey: '210',
+  key: '/library/metadata/210/children',
+  type: 'album',
+  title: 'Live at the Roundhouse',
+  parentTitle: 'The Static Charms',
+  parentRatingKey: '100',
+  addedAt: 1695000000,
+  originallyAvailableAt: '2022-11-04',
+  thumb: '/library/metadata/210/thumb/1713000000',
+};
+
+// Minimal-but-valid track entry, as returned by folder (by-folder browse) endpoints.
+const folderTrack = (options: {
+  ratingKey: string;
+  title: string;
+  album: string;
+  albumId: string;
+  discNumber: number;
+  trackNumber: number;
+}) => ({
+  ratingKey: options.ratingKey,
+  key: `/library/metadata/${options.ratingKey}`,
+  type: 'track',
+  title: options.title,
+  grandparentTitle: 'Analog Archive',
+  grandparentRatingKey: '102',
+  parentTitle: options.album,
+  parentRatingKey: options.albumId,
+  index: options.trackNumber,
+  parentIndex: options.discNumber,
+  Media: [
+    {
+      audioCodec: 'mp3',
+      container: 'mp3',
+      bitrate: 320,
+      duration: 180000,
+      Part: [{ key: `/library/parts/${options.ratingKey}/file.mp3` }],
+    },
+  ],
+});
+
+// ======================================================================
+// ALL USERS — plex.tv home users (no MediaContainer wrapper)
+// ======================================================================
+
+export const PLEX_ALL_USERS_RESPONSE = {
+  data: {
+    users: [
+      {
+        id: 111,
+        uuid: 'uuid-adam',
+        title: 'Adam',
+        username: 'adamd',
+        email: 'adam@example.com',
+        admin: true,
+        guest: false,
+        protected: true,
+        thumb: 'https://plex.tv/users/uuid-adam/avatar?c=1712345678',
+      },
+      {
+        id: 222,
+        uuid: 'uuid-kid',
+        title: '',
+        username: 'kiddo',
+        email: '',
+        admin: false,
+        guest: false,
+        protected: false,
+        restrictionProfile: 'little_kid',
+        thumb: 'https://plex.tv/users/uuid-kid/avatar?c=1712345678',
+      },
+    ],
+  },
+};
+
+// ======================================================================
+// USER — plex.tv account (no MediaContainer wrapper)
+// ======================================================================
+
+export const PLEX_USER_RESPONSE = {
+  data: {
+    id: 111,
+    uuid: 'uuid-adam',
+    title: 'Adam',
+    username: 'adamd',
+    email: 'adam@example.com',
+    thumb: 'https://plex.tv/users/uuid-adam/avatar?c=1712345678',
+  },
+};
+
+// ======================================================================
+// SERVERS — plex.tv resources (data is a plain array)
+// ======================================================================
+
+export const PLEX_RESOURCES_RESPONSE = {
+  data: [
+    {
+      name: 'Home Server',
+      provides: 'server',
+      clientIdentifier: 'abc123',
+      accessToken: 'server-token-1',
+      connections: [
+        {
+          protocol: 'https',
+          address: '192.168.1.10',
+          port: 32400,
+          uri: 'https://192-168-1-10.abc123.plex.direct:32400',
+          local: true,
+        },
+      ],
+    },
+    {
+      provides: 'server',
+      clientIdentifier: 'def456',
+      accessToken: 'server-token-2',
+      connections: [],
+    },
+    {
+      name: 'Living Room TV',
+      provides: 'client,player,pubsub-player',
+      clientIdentifier: 'tv-1',
+    },
+  ],
+};
+
+// ======================================================================
+// LIBRARIES
+// ======================================================================
+
+export const PLEX_LIBRARIES_RESPONSE = {
+  data: {
+    MediaContainer: {
+      size: 3,
+      Directory: [
+        { key: '20', type: 'artist', title: 'Music' },
+        { key: '2', type: 'movie', title: 'Movies' },
+        { key: '21', type: 'artist', title: 'Classical' },
+      ],
+    },
+  },
+};
+
+// ======================================================================
+// ARTISTS
+// ======================================================================
+
+export const PLEX_ARTISTS_RESPONSE = {
+  data: {
+    MediaContainer: {
+      size: 2,
+      Metadata: [
+        {
+          ratingKey: '100',
+          key: '/library/metadata/100/children',
+          type: 'artist',
+          title: 'The Static Charms',
+          Genre: [{ tag: 'Electronic' }],
+          Country: [{ tag: 'United Kingdom' }],
+          addedAt: 1680000000,
+          lastViewedAt: 1711000000,
+          userRating: 8,
+          thumb: '/library/metadata/100/thumb/1711111111',
+        },
+        {
+          ratingKey: '101',
+          key: '/library/metadata/101/children',
+          type: 'artist',
+          title: 'Various Artists',
+          addedAt: 1670000000,
+        },
+      ],
+    },
+  },
+};
+
+export const PLEX_ARTIST_RELATED_RESPONSE = {
+  data: {
+    MediaContainer: {
+      size: 1,
+      Metadata: [
+        {
+          ratingKey: '100',
+          type: 'artist',
+          title: 'The Static Charms',
+          Related: {
+            Hub: [
+              {
+                type: 'album',
+                context: 'hub.artist.albums',
+                title: 'Albums',
+                Metadata: [albumElectricNights],
+              },
+              {
+                type: 'album',
+                context: 'hub.artist.albums.live',
+                title: 'Live Albums, Singles & EPs',
+                Metadata: [albumLiveAtTheRoundhouse],
+              },
+              {
+                // No Metadata — must be excluded
+                type: 'album',
+                context: 'hub.artist.albums.compilations',
+                title: 'Compilations',
+              },
+              {
+                // Wrong type — must be excluded
+                type: 'artist',
+                context: 'hub.artist.similar',
+                title: 'Similar Artists',
+                Metadata: [{ ratingKey: '103', type: 'artist', title: 'Night Bus Collective' }],
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+};
+
+// ======================================================================
+// ALBUMS
+// ======================================================================
+
+export const PLEX_ALBUMS_RESPONSE = {
+  data: {
+    MediaContainer: {
+      size: 2,
+      Metadata: [albumElectricNights, albumCompilation],
+    },
+  },
+};
+
+// ======================================================================
+// FOLDERS
+// ======================================================================
+
+export const PLEX_FOLDERS_RESPONSE = {
+  data: {
+    MediaContainer: {
+      size: 4,
+      Metadata: [
+        folderTrack({
+          ratingKey: '6001',
+          title: 'Rehearsal Take',
+          album: 'Reel One',
+          albumId: '202',
+          discNumber: 1,
+          trackNumber: 1,
+        }),
+        // Non-track metadata row — must be excluded
+        { ratingKey: '203', key: '/library/metadata/203/children', type: 'album', title: 'Stray Album Row' },
+        { key: '/library/sections/20/all?parent=42', title: 'Zeta Sessions' },
+        { key: '/library/sections/20/all?parent=43', title: 'Alpha Takes' },
+      ],
+    },
+  },
+};
+
+export const PLEX_FOLDER_TRACKS_RESPONSE = {
+  data: {
+    MediaContainer: {
+      size: 4,
+      Metadata: [
+        folderTrack({
+          ratingKey: '6101',
+          title: 'Late Album Opener',
+          album: 'Zebra Crossing',
+          albumId: '250',
+          discNumber: 1,
+          trackNumber: 1,
+        }),
+        folderTrack({
+          ratingKey: '6102',
+          title: 'Second Disc Opener',
+          album: 'Aurora',
+          albumId: '251',
+          discNumber: 2,
+          trackNumber: 1,
+        }),
+        folderTrack({
+          ratingKey: '6103',
+          title: 'First Disc Closer',
+          album: 'Aurora',
+          albumId: '251',
+          discNumber: 1,
+          trackNumber: 2,
+        }),
+        folderTrack({
+          ratingKey: '6104',
+          title: 'First Disc Opener',
+          album: 'Aurora',
+          albumId: '251',
+          discNumber: 1,
+          trackNumber: 1,
+        }),
+      ],
+    },
+  },
+};
+
+// ======================================================================
+// PLAYLISTS
+// ======================================================================
+
+export const PLEX_PLAYLISTS_RESPONSE = {
+  data: {
+    MediaContainer: {
+      size: 4,
+      Metadata: [
+        {
+          ratingKey: '300',
+          key: '/playlists/300/items',
+          type: 'playlist',
+          title: 'Morning Coffee',
+          addedAt: 1701000000,
+          lastViewedAt: 1712500000,
+          userRating: 10,
+          leafCount: 25,
+          duration: 5400000,
+          thumb: '/library/metadata/300/thumb/1712000000',
+          composite: '/playlists/300/composite/1712345678',
+        },
+        {
+          ratingKey: '301',
+          key: '/playlists/301/items',
+          type: 'playlist',
+          title: 'Deep Focus',
+          leafCount: 40,
+          duration: 9000000,
+          composite: '/library/playlists/301/composite/1712345678',
+        },
+        {
+          ratingKey: '302',
+          key: '/playlists/302/items',
+          type: 'playlist',
+          title: 'Workout',
+          leafCount: 12,
+          duration: 2400000,
+          composite: '/library/playlists/302/composite/1712345678///',
+        },
+        {
+          ratingKey: '303',
+          key: '/playlists/303/items',
+          type: 'playlist',
+          title: 'New Playlist',
+          leafCount: 0,
+          duration: 0,
+        },
+      ],
+    },
+  },
+};
+
+// ======================================================================
+// COLLECTIONS
+// ======================================================================
+
+export const PLEX_COLLECTIONS_RESPONSE = {
+  data: {
+    MediaContainer: {
+      size: 3,
+      Metadata: [
+        {
+          ratingKey: '400',
+          type: 'collection',
+          subtype: 'artist',
+          title: 'Favourite Artists',
+          addedAt: 1699000000,
+          userRating: 7,
+          thumb: '/library/collections/400/thumb/1712345000',
+        },
+        {
+          ratingKey: '401',
+          type: 'collection',
+          subtype: 'album',
+          title: 'Best of 2020',
+          addedAt: 1698000000,
+          composite: '/library/collections/401/composite/1712345600',
+        },
+        {
+          // Unsupported subtype — must be excluded
+          ratingKey: '402',
+          type: 'collection',
+          subtype: 'photo',
+          title: 'Holiday Snaps',
+          addedAt: 1697000000,
+        },
+      ],
+    },
+  },
+};
+
+// ======================================================================
+// TAGS
+// ======================================================================
+
+export const PLEX_TAGS_RESPONSE = {
+  data: {
+    MediaContainer: {
+      size: 2,
+      Directory: [
+        { key: '9001', title: 'Rock/Pop' },
+        { key: '9002', title: 'Jazz' },
+      ],
+    },
+  },
+};
+
+// ======================================================================
+// TRACKS
+// ======================================================================
+
+export const PLEX_TRACKS_RESPONSE = {
+  data: {
+    MediaContainer: {
+      size: 4,
+      Metadata: [
+        {
+          // Standard album track
+          ratingKey: '5001',
+          key: '/library/metadata/5001',
+          type: 'track',
+          title: 'Opening Theme',
+          grandparentTitle: 'The Static Charms',
+          grandparentRatingKey: '100',
+          parentTitle: 'Electric Nights',
+          parentRatingKey: '200',
+          parentYear: 2020,
+          index: 1,
+          parentIndex: 1,
+          userRating: 10,
+          thumb: '/library/metadata/200/thumb/1712345678',
+          Media: [
+            {
+              id: 7001,
+              audioCodec: 'flac',
+              container: 'flac',
+              bitrate: 1043,
+              duration: 215000,
+              Part: [{ id: 8001, key: '/library/parts/9001/1650000001/file.flac' }],
+            },
+          ],
+        },
+        {
+          // Appearance track — originalTitle differs from grandparentTitle;
+          // no thumb, no parentYear, no userRating
+          ratingKey: '5002',
+          key: '/library/metadata/5002',
+          type: 'track',
+          title: 'Guest Spot',
+          originalTitle: 'The Featured Act',
+          grandparentTitle: 'Various Artists',
+          grandparentRatingKey: '101',
+          parentTitle: 'Compilation Vol. 1',
+          parentRatingKey: '201',
+          index: 2,
+          parentIndex: 1,
+          Media: [
+            {
+              id: 7002,
+              audioCodec: 'wmav2',
+              container: 'asf',
+              bitrate: 192,
+              duration: 180000,
+              Part: [{ id: 8002, key: '/library/parts/9002/1650000002/file.wma' }],
+            },
+          ],
+        },
+        {
+          // originalTitle matches grandparentTitle; thumb has a query string
+          ratingKey: '5003',
+          key: '/library/metadata/5003',
+          type: 'track',
+          title: 'Night Drive',
+          originalTitle: 'The Static Charms',
+          grandparentTitle: 'The Static Charms',
+          grandparentRatingKey: '100',
+          parentTitle: 'Electric Nights',
+          parentRatingKey: '200',
+          parentYear: 2020,
+          index: 3,
+          parentIndex: 1,
+          userRating: 6,
+          thumb: '/library/metadata/200/thumb/1712345678?X-Plex-Token=stale-token',
+          Media: [
+            {
+              id: 7003,
+              audioCodec: 'pcm',
+              container: 'wav',
+              bitrate: 1411,
+              duration: 95000,
+              Part: [{ id: 8003, key: '/library/parts/9003/1650000003/file.wav' }],
+            },
+          ],
+        },
+        {
+          // Playlist item on disc 2
+          ratingKey: '5004',
+          key: '/library/metadata/5004',
+          type: 'track',
+          playlistItemID: 90004,
+          title: 'Tape Restoration',
+          grandparentTitle: 'Analog Archive',
+          grandparentRatingKey: '102',
+          parentTitle: 'Reel One',
+          parentRatingKey: '202',
+          parentYear: 1974,
+          index: 4,
+          parentIndex: 2,
+          userRating: 4,
+          thumb: '/library/metadata/202/thumb/1710000000',
+          Media: [
+            {
+              id: 7004,
+              audioCodec: 'pcm',
+              container: 'aiff',
+              bitrate: 1411,
+              duration: 320000,
+              Part: [{ id: 8004, key: '/library/parts/9004/1650000004/file.aiff' }],
+            },
+          ],
+        },
+      ],
+    },
+  },
+};
+
+// ======================================================================
+// SEARCH RESULTS
+// ======================================================================
+
+export const PLEX_SEARCH_RESPONSE = {
+  data: {
+    MediaContainer: {
+      Hub: [
+        {
+          type: 'artist',
+          title: 'Artists',
+          Metadata: [
+            {
+              ratingKey: '100',
+              type: 'artist',
+              score: 0.9,
+              title: 'The Static Charms',
+              thumb: '/library/metadata/100/thumb/1711111111',
+            },
+            { ratingKey: '102', type: 'artist', score: 0.9, title: 'Analog Archive' },
+          ],
+        },
+        {
+          type: 'album',
+          title: 'Albums',
+          Metadata: [
+            {
+              ratingKey: '200',
+              type: 'album',
+              score: 0.95,
+              title: 'Electric Nights',
+              thumb: '/library/metadata/200/thumb/1712345678',
+            },
+          ],
+        },
+        {
+          type: 'track',
+          title: 'Tracks',
+          Metadata: [
+            {
+              ratingKey: '5001',
+              parentRatingKey: '200',
+              type: 'track',
+              score: 0.9,
+              title: 'Opening Theme',
+              thumb: '/library/metadata/200/thumb/1712345678',
+            },
+          ],
+        },
+        {
+          type: 'playlist',
+          title: 'Playlists',
+          Metadata: [
+            {
+              ratingKey: '301',
+              type: 'playlist',
+              score: 0.9,
+              title: 'Deep Focus',
+              composite: '/library/playlists/301/composite/1712345678',
+            },
+          ],
+        },
+        {
+          type: 'collection',
+          title: 'Collections',
+          Metadata: [
+            {
+              ratingKey: '401',
+              type: 'collection',
+              subtype: 'album',
+              score: 0.9,
+              title: 'Best of 2020',
+              composite: '/library/collections/401/composite/1712345600',
+            },
+          ],
+        },
+        {
+          // Unsupported result type — must be excluded
+          type: 'photo',
+          title: 'Photos',
+          Metadata: [{ ratingKey: '9999', type: 'photo', score: 0.99, title: 'Beach Day' }],
+        },
+        {
+          // Hub without Metadata — must be excluded
+          type: 'genre',
+          title: 'Genres',
+        },
+      ],
+    },
+  },
+};
+
+// ======================================================================
+// EMPTY
+// ======================================================================
+
+export const PLEX_EMPTY_RESPONSE = {
+  data: {
+    MediaContainer: {
+      size: 0,
+    },
+  },
+};

--- a/src/js/services/jellyTranspose.test.ts
+++ b/src/js/services/jellyTranspose.test.ts
@@ -1,0 +1,583 @@
+// Generated using Claude Code
+
+import { _clearCache } from 'js/utils/requiresTranscoding';
+
+import {
+  transposeUserData,
+  transposeServerData,
+  transposeLibraryArray,
+  transposeArtistArray,
+  transposeAlbumArtistArray,
+  transposeArtistDetails,
+  transposeAlbumArray,
+  transposeAlbumDetails,
+  transposePlaylistArray,
+  transposePlaylistDetails,
+  transposeTagArray,
+  transposeTrackArray,
+  transposeSearchResultsArray,
+} from './jellyTranspose';
+
+import {
+  JELLY_USER_RESPONSE,
+  JELLY_USER_NO_IMAGE_RESPONSE,
+  JELLY_SERVER_RESPONSE,
+  JELLY_SERVER_UNNAMED_RESPONSE,
+  JELLY_LIBRARIES_RESPONSE,
+  JELLY_ARTIST_PRIMARY,
+  JELLY_ARTIST_BACKDROP,
+  JELLY_ARTISTS_RESPONSE,
+  JELLY_ALBUM_MAIN,
+  JELLY_ALBUMS_RESPONSE,
+  JELLY_PLAYLIST_MAIN,
+  JELLY_PLAYLISTS_RESPONSE,
+  JELLY_TRACK_FLAC,
+  JELLY_TRACK_WMA,
+  JELLY_TRACK_MINIMAL,
+  JELLY_TRACK_ALBUM_ART,
+  JELLY_TRACK_BACKDROP,
+  JELLY_TRACK_PARENT_BACKDROP,
+  JELLY_SEARCH_RESPONSE,
+} from './__fixtures__/jellyfinApi';
+
+// ======================================================================
+// SHARED ARGUMENTS AND EXPECTED URL SHAPES
+// ======================================================================
+
+const serverBaseUrl = 'https://jellyfin.example.com';
+const accessToken = 'test-access-token';
+const libraryId = 'library-1';
+const userId = 'user-1';
+
+// Expected URL shapes, written out once so individual assertions stay readable.
+// Note that thumb URLs deliberately do NOT include the access token.
+const thumbUrl = (entryId: string, imageKey: string, size: number, tag: string) =>
+  `${serverBaseUrl}/Items/${entryId}/Images/${imageKey}?fillHeight=${size}&fillWidth=${size}&quality=96&tag=${tag}`;
+
+const directSrc = (trackId: string) => `${serverBaseUrl}/Audio/${trackId}/stream?static=true&api_key=${accessToken}`;
+
+const transcodeSrc = (trackId: string) =>
+  `${serverBaseUrl}/Audio/${trackId}/universal?api_key=${accessToken}&audioCodec=aac,mp3`;
+
+// ======================================================================
+// AUDIO CODEC SUPPORT MOCKING
+// ======================================================================
+
+// Track src selection calls requiresTranscoding(), which probes canPlayType on
+// an audio element created via document.createElement('audio') — a native jsdom
+// element, not our MockHTMLAudioElement. Spy on its prototype to control it.
+const nativeAudioProto = Object.getPrototypeOf(document.createElement('audio')) as HTMLAudioElement;
+
+const mockCanPlayType = (result: '' | 'maybe' | 'probably') => {
+  vi.spyOn(nativeAudioProto, 'canPlayType').mockReturnValue(result);
+};
+
+// requiresTranscoding caches canPlayType results per codec at module level, so
+// the cache must be cleared between tests to keep each test deterministic.
+afterEach(() => {
+  vi.restoreAllMocks();
+  _clearCache();
+});
+
+// ======================================================================
+// USER
+// ======================================================================
+
+describe('Testing "transposeUserData" function', () => {
+  test('Transposes user info including the profile image URL', () => {
+    const user = transposeUserData(JELLY_USER_RESPONSE, serverBaseUrl, accessToken, userId);
+    expect(user).toEqual({
+      userId: 'user-1',
+      email: null,
+      thumbSm: `${serverBaseUrl}/Users/${userId}/Images/Primary?tag=usertag123`,
+      displayName: 'demo-user',
+      serverBaseUrl,
+    });
+  });
+
+  test('Returns a null thumb when the user has no primary image', () => {
+    const user = transposeUserData(JELLY_USER_NO_IMAGE_RESPONSE, serverBaseUrl, accessToken, 'user-2');
+    expect(user.thumbSm).toBeNull();
+    expect(user.userId).toBe('user-2');
+  });
+});
+
+// ======================================================================
+// SERVERS
+// ======================================================================
+
+describe('Testing "transposeServerData" function', () => {
+  test('Transposes system info into a single-entry server array', () => {
+    const servers = transposeServerData(JELLY_SERVER_RESPONSE, accessToken);
+    expect(servers).toEqual([
+      {
+        serverId: 'server-1',
+        name: 'Home Media',
+        accessToken,
+        connections: undefined,
+      },
+    ]);
+  });
+
+  test('Falls back to a default name when ServerName is missing', () => {
+    const servers = transposeServerData(JELLY_SERVER_UNNAMED_RESPONSE, accessToken);
+    expect(servers[0].name).toBe('Unknown Jellyfin Server');
+  });
+});
+
+// ======================================================================
+// LIBRARIES
+// ======================================================================
+
+describe('Testing "transposeLibraryArray" function', () => {
+  test('Keeps only libraries with the music collection type', () => {
+    const libraries = transposeLibraryArray(JELLY_LIBRARIES_RESPONSE);
+    expect(libraries).toEqual([{ libraryId: 'library-1', title: 'Music' }]);
+  });
+
+  test('Returns undefined for missing input (no empty-array fallback)', () => {
+    // Unlike the other array transpose functions, this one has no `|| []` fallback.
+    expect(transposeLibraryArray(undefined)).toBeUndefined();
+    expect(transposeLibraryArray({ data: {} })).toBeUndefined();
+  });
+});
+
+// ======================================================================
+// ARTISTS
+// ======================================================================
+
+describe('Testing "transposeArtistArray" function', () => {
+  test('Transposes a fully-populated artist with all fields mapped', () => {
+    const artists = transposeArtistArray(JELLY_ARTISTS_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    expect(artists).toHaveLength(2);
+    expect(artists[0]).toEqual({
+      kind: 'artist',
+      libraryId,
+      artistId: 'artist-1',
+      title: 'The Midnight Owls',
+      genre: 'Indie Rock',
+      country: null,
+      addedAt: null,
+      lastPlayed: null,
+      userRating: null,
+      isFavourite: true,
+      link: '/libraries/library-1/artists/artist-1',
+      thumbSm: thumbUrl('artist-1', 'Primary', 360, 'artistprimary1'),
+      thumbMd: thumbUrl('artist-1', 'Primary', 680, 'artistprimary1'),
+    });
+  });
+
+  test('Falls back to the backdrop image and defaults when fields are missing', () => {
+    const artists = transposeArtistArray(JELLY_ARTISTS_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    expect(artists[1].thumbSm).toBe(thumbUrl('artist-2', 'Backdrop', 360, 'artistbackdrop2'));
+    expect(artists[1].genre).toBeUndefined();
+    expect(artists[1].isFavourite).toBe(false);
+  });
+
+  test('Returns an empty array for missing input', () => {
+    expect(transposeArtistArray(undefined, libraryId, serverBaseUrl, accessToken)).toEqual([]);
+    expect(transposeArtistArray({ data: {} }, libraryId, serverBaseUrl, accessToken)).toEqual([]);
+  });
+});
+
+describe('Testing "transposeAlbumArtistArray" function', () => {
+  test('Builds links under the album-artists path', () => {
+    const artists = transposeAlbumArtistArray(JELLY_ARTISTS_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    expect(artists[0].link).toBe('/libraries/library-1/album-artists/artist-1');
+    expect(artists[1].link).toBe('/libraries/library-1/album-artists/artist-2');
+  });
+
+  test('Returns an empty array for missing input', () => {
+    expect(transposeAlbumArtistArray(undefined, libraryId, serverBaseUrl, accessToken)).toEqual([]);
+  });
+});
+
+describe('Testing "transposeArtistDetails" function', () => {
+  test('Transposes a single artist response', () => {
+    const artist = transposeArtistDetails({ data: JELLY_ARTIST_PRIMARY }, libraryId, serverBaseUrl, accessToken);
+    expect(artist.artistId).toBe('artist-1');
+    expect(artist.title).toBe('The Midnight Owls');
+    expect(artist.link).toBe('/libraries/library-1/artists/artist-1');
+  });
+
+  test('Falls back to the backdrop image when the artist has no primary image', () => {
+    const artist = transposeArtistDetails({ data: JELLY_ARTIST_BACKDROP }, libraryId, serverBaseUrl, accessToken);
+    expect(artist.artistId).toBe('artist-2');
+    expect(artist.thumbSm).toBe(thumbUrl('artist-2', 'Backdrop', 360, 'artistbackdrop2'));
+  });
+});
+
+// ======================================================================
+// ALBUMS
+// ======================================================================
+
+describe('Testing "transposeAlbumArray" function', () => {
+  test('Transposes a fully-populated album with all fields mapped', () => {
+    const albums = transposeAlbumArray(JELLY_ALBUMS_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    expect(albums).toHaveLength(3);
+    expect(albums[0]).toEqual({
+      kind: 'album',
+      libraryId,
+      albumId: 'album-1',
+      title: 'Nocturnal Songs',
+      artist: 'The Midnight Owls',
+      // 'artist-1' matches AlbumArtist by name and must win over the first entry.
+      artistId: 'artist-1',
+      artistLink: '/libraries/library-1/artists/artist-1',
+      genre: 'Indie Rock',
+      addedAt: null,
+      lastPlayed: null,
+      userRating: null,
+      isFavourite: true,
+      releaseDate: '2019-03-15T00:00:00.0000000Z',
+      link: '/libraries/library-1/albums/album-1',
+      thumbSm: thumbUrl('album-1', 'Primary', 360, 'albumprimary1'),
+      thumbMd: thumbUrl('album-1', 'Primary', 680, 'albumprimary1'),
+    });
+  });
+
+  test('Falls back to the first album artist when none matches the AlbumArtist name', () => {
+    const albums = transposeAlbumArray(JELLY_ALBUMS_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    expect(albums[1].artist).toBe('Various Artists');
+    expect(albums[1].artistId).toBe('artist-3');
+    expect(albums[1].artistLink).toBe('/libraries/library-1/artists/artist-3');
+  });
+
+  test('Uses null artistId and null thumbs when artists and images are missing', () => {
+    const albums = transposeAlbumArray(JELLY_ALBUMS_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    expect(albums[2].artistId).toBeNull();
+    expect(albums[2].artistLink).toBe('/libraries/library-1/artists/null');
+    expect(albums[2].isFavourite).toBe(false);
+    expect(albums[2].thumbSm).toBeNull();
+    expect(albums[2].thumbMd).toBeNull();
+  });
+
+  test('Returns an empty array for missing input', () => {
+    expect(transposeAlbumArray(undefined, libraryId, serverBaseUrl, accessToken)).toEqual([]);
+    expect(transposeAlbumArray({ data: {} }, libraryId, serverBaseUrl, accessToken)).toEqual([]);
+  });
+});
+
+describe('Testing "transposeAlbumDetails" function', () => {
+  test('Transposes a single album response', () => {
+    const album = transposeAlbumDetails({ data: JELLY_ALBUM_MAIN }, libraryId, serverBaseUrl, accessToken);
+    expect(album.albumId).toBe('album-1');
+    expect(album.title).toBe('Nocturnal Songs');
+    expect(album.link).toBe('/libraries/library-1/albums/album-1');
+  });
+});
+
+// ======================================================================
+// PLAYLISTS
+// ======================================================================
+
+describe('Testing "transposePlaylistArray" function', () => {
+  test('Transposes a playlist with all fields mapped', () => {
+    const playlists = transposePlaylistArray(JELLY_PLAYLISTS_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    expect(playlists).toEqual([
+      {
+        kind: 'playlist',
+        libraryId,
+        playlistId: 'playlist-1',
+        title: 'Late Night Drive',
+        addedAt: null,
+        lastPlayed: null,
+        userRating: null,
+        isFavourite: true,
+        link: '/libraries/library-1/playlists/playlist-1',
+        totalTracks: 24,
+        // RunTimeTicks (100ns units) converted to milliseconds.
+        duration: 5400000,
+        thumbSm: thumbUrl('playlist-1', 'Primary', 360, 'playlistprimary1'),
+        thumbMd: thumbUrl('playlist-1', 'Primary', 680, 'playlistprimary1'),
+      },
+    ]);
+  });
+
+  test('Returns an empty array for missing input', () => {
+    expect(transposePlaylistArray(undefined, libraryId, serverBaseUrl, accessToken)).toEqual([]);
+  });
+});
+
+describe('Testing "transposePlaylistDetails" function', () => {
+  test('Transposes a single playlist response', () => {
+    const playlist = transposePlaylistDetails({ data: JELLY_PLAYLIST_MAIN }, libraryId, serverBaseUrl, accessToken);
+    expect(playlist.playlistId).toBe('playlist-1');
+    expect(playlist.totalTracks).toBe(24);
+    expect(playlist.link).toBe('/libraries/library-1/playlists/playlist-1');
+  });
+});
+
+// ======================================================================
+// TAGS
+// ======================================================================
+
+describe('Testing "transposeTagArray" function', () => {
+  test('Transposes genre strings, encoding ids and replacing slashes in titles', () => {
+    const genres = transposeTagArray(['Rock', 'Drum/Bass'], libraryId, 'artist', 'Genre');
+    expect(genres).toEqual([
+      {
+        kind: 'genre',
+        libraryId,
+        genreId: 'Rock',
+        title: 'Rock',
+        link: '/libraries/library-1/artist-genres/Rock',
+      },
+      {
+        kind: 'genre',
+        libraryId,
+        genreId: 'Drum__SLSH__Bass',
+        title: 'Drum & Bass',
+        link: '/libraries/library-1/artist-genres/Drum__SLSH__Bass',
+      },
+    ]);
+  });
+
+  test('Transposes tag strings under the given primary key', () => {
+    const tags = transposeTagArray(['Live'], libraryId, 'album', 'Tag');
+    expect(tags).toEqual([
+      {
+        kind: 'tag',
+        libraryId,
+        tagId: 'Live',
+        title: 'Live',
+        link: '/libraries/library-1/album-tags/Live',
+      },
+    ]);
+  });
+
+  test('Returns an empty array for missing input', () => {
+    expect(transposeTagArray(undefined, libraryId, 'artist', 'Genre')).toEqual([]);
+  });
+});
+
+// ======================================================================
+// TRACKS
+// ======================================================================
+
+describe('Testing "transposeTrackArray" function', () => {
+  // Default to a browser that can play everything; individual tests override this.
+  beforeEach(() => {
+    mockCanPlayType('probably');
+  });
+
+  const transposeTracks = (items: object[]) =>
+    transposeTrackArray({ data: { Items: items } }, libraryId, serverBaseUrl, accessToken);
+
+  const trackWithCodec = (codec: string) => ({
+    ...JELLY_TRACK_FLAC,
+    MediaStreams: [{ Codec: codec, Type: 'Audio', Index: 0, BitRate: 1000000 }],
+  });
+
+  test('Transposes a fully-populated track with all fields mapped', () => {
+    const tracks = transposeTracks([JELLY_TRACK_FLAC]);
+    expect(tracks).toEqual([
+      {
+        kind: 'track',
+        libraryId,
+        trackId: 'track-1',
+        trackKey: null,
+        playlistItemID: 'playlistitem-77',
+        title: 'City Lights',
+        artist: 'The Midnight Owls',
+        // 'artist-1' matches AlbumArtist by name and must win over the first entry.
+        artistLink: '/libraries/library-1/artists/artist-1',
+        album: 'Nocturnal Songs',
+        albumId: 'album-1',
+        albumLink: '/libraries/library-1/albums/album-1',
+        trackNumber: 3,
+        discNumber: 1,
+        // Codec and bitrate come from the 'Audio' stream, not the 'EmbeddedImage' one.
+        codec: 'flac',
+        bitrate: 1411,
+        // RunTimeTicks (100ns units) converted to milliseconds.
+        duration: 216000,
+        userRating: null,
+        isFavourite: true,
+        releaseDate: '2019-03-15T00:00:00.0000000Z',
+        // The track's own Primary image wins over the AlbumPrimaryImageTag fallback.
+        thumbSm: thumbUrl('track-1', 'Primary', 360, 'trackprimary1'),
+        thumbMd: thumbUrl('track-1', 'Primary', 680, 'trackprimary1'),
+        src: directSrc('track-1'),
+      },
+    ]);
+  });
+
+  test('Rounds bitrate to the nearest kbps', () => {
+    // 192500 bps rounds up to 193 kbps.
+    const tracks = transposeTracks([JELLY_TRACK_WMA]);
+    expect(tracks[0].bitrate).toBe(193);
+  });
+
+  test('Falls back to the first album artist when none matches the AlbumArtist name', () => {
+    const tracks = transposeTracks([{ ...JELLY_TRACK_FLAC, AlbumArtist: 'Someone Else' }]);
+    expect(tracks[0].artist).toBe('Someone Else');
+    expect(tracks[0].artistLink).toBe('/libraries/library-1/artists/artist-2');
+  });
+
+  test('Uses the direct stream endpoint for natively playable codecs', () => {
+    mockCanPlayType('probably');
+    const tracks = transposeTracks([JELLY_TRACK_FLAC]);
+    expect(tracks[0].src).toBe(directSrc('track-1'));
+  });
+
+  test('Uses the universal transcoding endpoint when the browser cannot play the codec', () => {
+    mockCanPlayType('');
+    const tracks = transposeTracks([JELLY_TRACK_FLAC]);
+    expect(tracks[0].src).toBe(transcodeSrc('track-1'));
+  });
+
+  test('Uses the universal transcoding endpoint for codecs with no known MIME type', () => {
+    // 'ape' is not in the codec MIME map, so it always requires transcoding —
+    // even though canPlayType is mocked to report support for everything.
+    mockCanPlayType('probably');
+    const tracks = transposeTracks([trackWithCodec('ape')]);
+    expect(tracks[0].codec).toBe('ape');
+    expect(tracks[0].src).toBe(transcodeSrc('track-1'));
+  });
+
+  test('Maps raw PCM and WMA codec identifiers to display names', () => {
+    const tracks = transposeTracks([
+      trackWithCodec('pcm_s16le'),
+      trackWithCodec('pcm_s24le'),
+      trackWithCodec('pcm_s16be'),
+      trackWithCodec('wmav2'),
+      trackWithCodec('mp3'),
+    ]);
+    expect(tracks.map((track: { codec: string }) => track.codec)).toEqual(['wav', 'wav', 'aiff', 'wma', 'mp3']);
+  });
+
+  test('Falls back to the album primary image when the track has no images', () => {
+    const tracks = transposeTracks([JELLY_TRACK_ALBUM_ART]);
+    expect(tracks[0].thumbSm).toBe(thumbUrl('album-1', 'Primary', 360, 'albumprimary1'));
+    expect(tracks[0].thumbMd).toBe(thumbUrl('album-1', 'Primary', 680, 'albumprimary1'));
+  });
+
+  test('Falls back to the track backdrop when no primary images exist', () => {
+    const tracks = transposeTracks([JELLY_TRACK_BACKDROP]);
+    expect(tracks[0].thumbSm).toBe(thumbUrl('track-5', 'Backdrop', 360, 'trackbackdrop5'));
+  });
+
+  test('Falls back to the album backdrop as the last resort', () => {
+    const tracks = transposeTracks([JELLY_TRACK_PARENT_BACKDROP]);
+    expect(tracks[0].thumbSm).toBe(thumbUrl('album-1', 'Backdrop', 360, 'parentbackdrop1'));
+  });
+
+  test('Does not include the access token in thumb URLs', () => {
+    const tracks = transposeTracks([JELLY_TRACK_FLAC]);
+    expect(tracks[0].thumbSm).not.toContain(accessToken);
+    expect(tracks[0].src).toContain(accessToken);
+  });
+
+  test('Transposes a minimal track with defaults for all missing fields', () => {
+    const tracks = transposeTracks([JELLY_TRACK_MINIMAL]);
+    expect(tracks).toEqual([
+      {
+        kind: 'track',
+        libraryId,
+        trackId: 'track-3',
+        trackKey: null,
+        playlistItemID: undefined,
+        title: 'Untitled',
+        artist: undefined,
+        // Current behaviour: missing ids are interpolated into link strings.
+        artistLink: '/libraries/library-1/artists/null',
+        album: undefined,
+        albumId: undefined,
+        albumLink: '/libraries/library-1/albums/undefined',
+        trackNumber: undefined,
+        discNumber: undefined,
+        codec: undefined,
+        bitrate: null,
+        duration: NaN,
+        userRating: null,
+        isFavourite: false,
+        releaseDate: null,
+        thumbSm: null,
+        thumbMd: null,
+        // A missing codec always requires transcoding.
+        src: transcodeSrc('track-3'),
+      },
+    ]);
+  });
+
+  test('Returns an empty array for missing input', () => {
+    expect(transposeTrackArray(undefined, libraryId, serverBaseUrl, accessToken)).toEqual([]);
+    expect(transposeTrackArray({ data: {} }, libraryId, serverBaseUrl, accessToken)).toEqual([]);
+    expect(transposeTracks([])).toEqual([]);
+  });
+});
+
+// ======================================================================
+// SEARCH RESULTS
+// ======================================================================
+
+describe('Testing "transposeSearchResultsArray" function', () => {
+  test('Sorts results by type then title, dropping unsupported types', () => {
+    const results = transposeSearchResultsArray(JELLY_SEARCH_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    expect(results.map((result: { title: string }) => result.title)).toEqual([
+      'Alpha Court',
+      'Beta Waves',
+      'Basement Sessions',
+      'Morning Mix',
+      'Alpine Air',
+      'Zebra Crossing',
+    ]);
+    expect(results.map((result: { type: string }) => result.type)).toEqual([
+      'artist',
+      'artist',
+      'album',
+      'playlist',
+      'track',
+      'track',
+    ]);
+  });
+
+  test('Maps each result type to its id, icon, link, and thumb', () => {
+    const results = transposeSearchResultsArray(JELLY_SEARCH_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    expect(results[1]).toEqual({
+      artistId: 'artist-21',
+      type: 'artist',
+      icon: 'PeopleIcon',
+      title: 'Beta Waves',
+      link: '/libraries/library-1/artists/artist-21',
+      thumbSm: thumbUrl('artist-21', 'Primary', 360, 'searchartist21'),
+    });
+    expect(results[2]).toEqual({
+      albumId: 'album-24',
+      type: 'album',
+      icon: 'PlayCircleIcon',
+      title: 'Basement Sessions',
+      link: '/libraries/library-1/albums/album-24',
+      thumbSm: null,
+    });
+    expect(results[3]).toEqual({
+      playlistId: 'playlist-22',
+      type: 'playlist',
+      icon: 'PlaylistIcon',
+      title: 'Morning Mix',
+      link: '/libraries/library-1/playlists/playlist-22',
+      thumbSm: null,
+    });
+  });
+
+  test('Links track results to the parent album, falling back to AlbumId', () => {
+    const results = transposeSearchResultsArray(JELLY_SEARCH_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    // 'Alpine Air' has both ParentId and AlbumId — ParentId wins.
+    expect(results[4]).toEqual({
+      trackId: 'track-23',
+      type: 'track',
+      icon: 'MusicNoteSingleIcon',
+      title: 'Alpine Air',
+      link: '/libraries/library-1/albums/album-23',
+      thumbSm: null,
+    });
+    // 'Zebra Crossing' has only AlbumId.
+    expect(results[5].link).toBe('/libraries/library-1/albums/album-20');
+  });
+
+  test('Returns an empty array for missing input', () => {
+    expect(transposeSearchResultsArray(undefined, libraryId, serverBaseUrl, accessToken)).toEqual([]);
+    expect(transposeSearchResultsArray({ data: {} }, libraryId, serverBaseUrl, accessToken)).toEqual([]);
+  });
+});

--- a/src/js/services/player.test.ts
+++ b/src/js/services/player.test.ts
@@ -1,0 +1,403 @@
+// Generated using Claude Code
+
+/**
+ * Player Router Test Suite
+ *
+ * Validates the routing layer that dispatches playback between the native
+ * player and the DASH player. Both sub-players are mocked, so these tests
+ * assert pure routing behaviour: which sub-player receives each call, and
+ * how the module-level activePlayer state gates init() event callbacks.
+ *
+ * The router holds module-level state (activePlayer), so each test reimports
+ * the module fresh via vi.resetModules() + dynamic import.
+ *
+ * Codec routing goes through requiresTranscoding(), which probes canPlayType()
+ * on a real (jsdom) audio element — tests control the result by spying on that
+ * element's prototype. requiresTranscoding's module-level result cache is also
+ * recreated by vi.resetModules(), so each test starts from a clean slate.
+ */
+
+// ======================================================================
+// SUB-PLAYER MOCKS
+// ======================================================================
+
+// Created via vi.hoisted so the vi.mock factories (which are hoisted above
+// imports) can reference them, and so the same mock instances survive the
+// vi.resetModules() call in beforeEach.
+const { nativeMock, dashMock } = vi.hoisted(() => {
+  const createSubPlayerMock = () => ({
+    init: vi.fn(),
+    unload: vi.fn(),
+    loadTrack: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    restart: vi.fn(),
+    setProgress: vi.fn(),
+    getCurrentProgress: vi.fn(),
+    setVolume: vi.fn(),
+  });
+  return {
+    nativeMock: createSubPlayerMock(),
+    dashMock: { ...createSubPlayerMock(), isSupported: vi.fn() },
+  };
+});
+
+vi.mock('./player.native', () => nativeMock);
+vi.mock('./player.dash', () => dashMock);
+
+// ======================================================================
+// HELPERS
+// ======================================================================
+
+type PlayerRouter = typeof import('./player');
+
+// requiresTranscoding.ts creates its probe element via document.createElement('audio'),
+// which in jsdom gives a native element distinct from our MockHTMLAudioElement.
+// We must spy on that element's actual prototype to control codec support results.
+const nativeAudioProto = Object.getPrototypeOf(document.createElement('audio')) as HTMLAudioElement;
+
+const mockCanPlayType = (result: '' | 'maybe' | 'probably') => {
+  vi.spyOn(nativeAudioProto, 'canPlayType').mockReturnValue(result);
+};
+
+// A track whose codec the browser can play natively (canPlayType mocked to 'probably').
+const nativeTrack = {
+  src: 'http://example.com/track.mp3',
+  codec: 'mp3',
+};
+
+// A Plex track whose codec requires transcoding (canPlayType mocked to ''),
+// with a DASH manifest available.
+const dashTrack = {
+  src: 'http://example.com/track.flac',
+  dashSrc: 'http://example.com/track.mpd',
+  codec: 'flac',
+  trackKey: '/library/metadata/1001',
+};
+
+// ======================================================================
+// TESTS
+// ======================================================================
+
+describe('Testing "player" router service', () => {
+  let player: PlayerRouter;
+
+  const createInitParams = () => ({
+    volumeLevel: 75,
+    volumeMuted: false,
+    onLoadStart: vi.fn(),
+    onCanPlay: vi.fn(),
+    onEnded: vi.fn(),
+    onError: vi.fn(),
+  });
+
+  const loadNativeTrack = () => {
+    mockCanPlayType('probably');
+    player.loadTrack(nativeTrack);
+  };
+
+  const loadDashTrack = () => {
+    mockCanPlayType('');
+    player.loadTrack(dashTrack);
+  };
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    vi.resetModules();
+    dashMock.isSupported.mockReturnValue(true);
+    player = await import('./player');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ======================================================================
+  // TRACK LOADING
+  // ======================================================================
+
+  describe('Track Loading', () => {
+    test('Routes a natively playable codec to the native player', () => {
+      mockCanPlayType('probably');
+      const result = player.loadTrack(nativeTrack);
+      expect(result).toBe(true);
+      expect(nativeMock.loadTrack).toHaveBeenCalledWith(nativeTrack.src, 0, true);
+      expect(dashMock.loadTrack).not.toHaveBeenCalled();
+      // The DASH player is unloaded so it cannot keep playing underneath.
+      expect(dashMock.unload).toHaveBeenCalledTimes(1);
+      expect(nativeMock.unload).not.toHaveBeenCalled();
+    });
+
+    test('Forwards progress and play arguments to the native player', () => {
+      mockCanPlayType('probably');
+      player.loadTrack(nativeTrack, 30000, false);
+      expect(nativeMock.loadTrack).toHaveBeenCalledWith(nativeTrack.src, 30000, false);
+    });
+
+    test('Routes a transcode-required track with a dashSrc to the DASH player', () => {
+      mockCanPlayType('');
+      const result = player.loadTrack(dashTrack);
+      expect(result).toBe(true);
+      expect(dashMock.loadTrack).toHaveBeenCalledWith(dashTrack.dashSrc, 0, true);
+      expect(nativeMock.loadTrack).not.toHaveBeenCalled();
+      // The native player is unloaded so it cannot keep playing underneath.
+      expect(nativeMock.unload).toHaveBeenCalledTimes(1);
+      expect(dashMock.unload).not.toHaveBeenCalled();
+    });
+
+    test('Forwards progress and play arguments to the DASH player', () => {
+      mockCanPlayType('');
+      player.loadTrack(dashTrack, 45000, false);
+      expect(dashMock.loadTrack).toHaveBeenCalledWith(dashTrack.dashSrc, 45000, false);
+    });
+
+    test('Returns false and unloads both players when a Plex DASH track has no dashSrc yet', () => {
+      // Plex track that needs DASH but credentials are not ready — dashSrc is
+      // unavailable while trackKey identifies it as a Plex track.
+      mockCanPlayType('');
+      const result = player.loadTrack({ ...dashTrack, dashSrc: null });
+      expect(result).toBe(false);
+      expect(nativeMock.unload).toHaveBeenCalledTimes(1);
+      expect(dashMock.unload).toHaveBeenCalledTimes(1);
+      expect(nativeMock.loadTrack).not.toHaveBeenCalled();
+      expect(dashMock.loadTrack).not.toHaveBeenCalled();
+    });
+
+    test('Falls back to the native player when transcoding is required but DASH is unsupported', () => {
+      mockCanPlayType('');
+      dashMock.isSupported.mockReturnValue(false);
+      const result = player.loadTrack(dashTrack);
+      expect(result).toBe(true);
+      expect(nativeMock.loadTrack).toHaveBeenCalledWith(dashTrack.src, 0, true);
+      expect(dashMock.loadTrack).not.toHaveBeenCalled();
+    });
+
+    test('Routes a transcode-required track without dashSrc or trackKey to the native player', () => {
+      // Jellyfin case: the src URL already embeds server-side transcoding
+      // (universal endpoint), so no DASH manifest or Plex trackKey exists.
+      mockCanPlayType('');
+      const jellyfinTrack = { src: 'http://example.com/universal.flac', codec: 'flac' };
+      const result = player.loadTrack(jellyfinTrack);
+      expect(result).toBe(true);
+      expect(nativeMock.loadTrack).toHaveBeenCalledWith(jellyfinTrack.src, 0, true);
+      expect(dashMock.loadTrack).not.toHaveBeenCalled();
+    });
+
+    test('Treats a missing codec as requiring transcoding and routes to the DASH player', () => {
+      const result = player.loadTrack({ ...dashTrack, codec: null });
+      expect(result).toBe(true);
+      expect(dashMock.loadTrack).toHaveBeenCalledWith(dashTrack.dashSrc, 0, true);
+      expect(nativeMock.loadTrack).not.toHaveBeenCalled();
+    });
+  });
+
+  // ======================================================================
+  // PLAYBACK CONTROL ROUTING
+  // ======================================================================
+
+  describe('Playback Control Routing', () => {
+    test('Routes controls to the native player by default (before any load)', () => {
+      player.pause();
+      player.resume();
+      expect(nativeMock.pause).toHaveBeenCalledTimes(1);
+      expect(nativeMock.resume).toHaveBeenCalledTimes(1);
+      expect(dashMock.pause).not.toHaveBeenCalled();
+      expect(dashMock.resume).not.toHaveBeenCalled();
+    });
+
+    test('Routes all controls to the native player after a native load', () => {
+      loadNativeTrack();
+      nativeMock.getCurrentProgress.mockReturnValue(33);
+
+      player.pause();
+      player.resume();
+      player.restart();
+      player.setProgress(45000);
+      expect(player.getCurrentProgress()).toBe(33);
+
+      expect(nativeMock.pause).toHaveBeenCalledTimes(1);
+      expect(nativeMock.resume).toHaveBeenCalledTimes(1);
+      expect(nativeMock.restart).toHaveBeenCalledTimes(1);
+      expect(nativeMock.setProgress).toHaveBeenCalledWith(45000);
+      expect(nativeMock.getCurrentProgress).toHaveBeenCalledTimes(1);
+
+      expect(dashMock.pause).not.toHaveBeenCalled();
+      expect(dashMock.resume).not.toHaveBeenCalled();
+      expect(dashMock.restart).not.toHaveBeenCalled();
+      expect(dashMock.setProgress).not.toHaveBeenCalled();
+      expect(dashMock.getCurrentProgress).not.toHaveBeenCalled();
+    });
+
+    test('Routes all controls to the DASH player after a DASH load', () => {
+      loadDashTrack();
+      dashMock.getCurrentProgress.mockReturnValue(42);
+
+      player.pause();
+      player.resume();
+      player.restart();
+      player.setProgress(45000);
+      expect(player.getCurrentProgress()).toBe(42);
+
+      expect(dashMock.pause).toHaveBeenCalledTimes(1);
+      expect(dashMock.resume).toHaveBeenCalledTimes(1);
+      expect(dashMock.restart).toHaveBeenCalledTimes(1);
+      expect(dashMock.setProgress).toHaveBeenCalledWith(45000);
+      expect(dashMock.getCurrentProgress).toHaveBeenCalledTimes(1);
+
+      expect(nativeMock.pause).not.toHaveBeenCalled();
+      expect(nativeMock.resume).not.toHaveBeenCalled();
+      expect(nativeMock.restart).not.toHaveBeenCalled();
+      expect(nativeMock.setProgress).not.toHaveBeenCalled();
+      expect(nativeMock.getCurrentProgress).not.toHaveBeenCalled();
+    });
+
+    test('Reverts routing to the native player when a native track follows a DASH track', () => {
+      loadDashTrack();
+      loadNativeTrack();
+      player.pause();
+      expect(nativeMock.pause).toHaveBeenCalledTimes(1);
+      expect(dashMock.pause).not.toHaveBeenCalled();
+    });
+  });
+
+  // ======================================================================
+  // VOLUME
+  // ======================================================================
+
+  describe('Volume', () => {
+    test('Fans setVolume out to both players when native is active', () => {
+      loadNativeTrack();
+      player.setVolume(65);
+      expect(nativeMock.setVolume).toHaveBeenCalledWith(65);
+      expect(dashMock.setVolume).toHaveBeenCalledWith(65);
+    });
+
+    test('Fans setVolume out to both players when DASH is active', () => {
+      loadDashTrack();
+      player.setVolume(30);
+      expect(nativeMock.setVolume).toHaveBeenCalledWith(30);
+      expect(dashMock.setVolume).toHaveBeenCalledWith(30);
+    });
+  });
+
+  // ======================================================================
+  // UNLOAD
+  // ======================================================================
+
+  describe('Unload', () => {
+    test('Unloads both players', () => {
+      loadDashTrack();
+      player.unload();
+      expect(nativeMock.unload).toHaveBeenCalled();
+      expect(dashMock.unload).toHaveBeenCalled();
+    });
+
+    test('Resets routing to the native player', () => {
+      loadDashTrack();
+      player.unload();
+      player.pause();
+      expect(nativeMock.pause).toHaveBeenCalledTimes(1);
+      expect(dashMock.pause).not.toHaveBeenCalled();
+    });
+  });
+
+  // ======================================================================
+  // INIT CALLBACK GATING
+  // ======================================================================
+
+  describe('Init Callback Gating', () => {
+    test('Initialises both sub-players with the volume settings and wrapped callbacks', () => {
+      const params = createInitParams();
+      player.init(params);
+
+      expect(nativeMock.init).toHaveBeenCalledTimes(1);
+      expect(dashMock.init).toHaveBeenCalledTimes(1);
+      expect(nativeMock.init).toHaveBeenCalledWith(expect.objectContaining({ volumeLevel: 75, volumeMuted: false }));
+      expect(dashMock.init).toHaveBeenCalledWith(expect.objectContaining({ volumeLevel: 75, volumeMuted: false }));
+
+      // Callbacks are wrapped (gated on activePlayer), not passed through as-is.
+      const nativeWrapped = nativeMock.init.mock.calls[0][0];
+      const dashWrapped = dashMock.init.mock.calls[0][0];
+      expect(nativeWrapped.onEnded).toBeTypeOf('function');
+      expect(nativeWrapped.onEnded).not.toBe(params.onEnded);
+      expect(dashWrapped.onEnded).toBeTypeOf('function');
+      expect(dashWrapped.onEnded).not.toBe(params.onEnded);
+    });
+
+    test('Forwards native events and suppresses DASH events before any load (native is default)', () => {
+      const params = createInitParams();
+      player.init(params);
+      const nativeWrapped = nativeMock.init.mock.calls[0][0];
+      const dashWrapped = dashMock.init.mock.calls[0][0];
+
+      nativeWrapped.onLoadStart();
+      nativeWrapped.onCanPlay();
+      nativeWrapped.onEnded();
+      expect(params.onLoadStart).toHaveBeenCalledTimes(1);
+      expect(params.onCanPlay).toHaveBeenCalledTimes(1);
+      expect(params.onEnded).toHaveBeenCalledTimes(1);
+
+      // Stale events from the inactive DASH player must not leak through.
+      dashWrapped.onLoadStart();
+      dashWrapped.onCanPlay();
+      dashWrapped.onEnded();
+      expect(params.onLoadStart).toHaveBeenCalledTimes(1);
+      expect(params.onCanPlay).toHaveBeenCalledTimes(1);
+      expect(params.onEnded).toHaveBeenCalledTimes(1);
+    });
+
+    test('Forwards DASH events and suppresses native events after a DASH load', () => {
+      const params = createInitParams();
+      player.init(params);
+      loadDashTrack();
+      const nativeWrapped = nativeMock.init.mock.calls[0][0];
+      const dashWrapped = dashMock.init.mock.calls[0][0];
+
+      nativeWrapped.onLoadStart();
+      nativeWrapped.onCanPlay();
+      nativeWrapped.onEnded();
+      expect(params.onLoadStart).not.toHaveBeenCalled();
+      expect(params.onCanPlay).not.toHaveBeenCalled();
+      expect(params.onEnded).not.toHaveBeenCalled();
+
+      dashWrapped.onLoadStart();
+      dashWrapped.onCanPlay();
+      dashWrapped.onEnded();
+      expect(params.onLoadStart).toHaveBeenCalledTimes(1);
+      expect(params.onCanPlay).toHaveBeenCalledTimes(1);
+      expect(params.onEnded).toHaveBeenCalledTimes(1);
+    });
+
+    test('Gates onError by active player and forwards the error payload through', () => {
+      const params = createInitParams();
+      player.init(params);
+      loadDashTrack();
+      const nativeWrapped = nativeMock.init.mock.calls[0][0];
+      const dashWrapped = dashMock.init.mock.calls[0][0];
+      const errorPayload = { event: new Event('error'), playerElement: document.createElement('audio') };
+
+      // A stale error from the inactive native player is suppressed.
+      nativeWrapped.onError(errorPayload);
+      expect(params.onError).not.toHaveBeenCalled();
+
+      // An error from the active DASH player is forwarded with its payload intact.
+      dashWrapped.onError(errorPayload);
+      expect(params.onError).toHaveBeenCalledTimes(1);
+      expect(params.onError).toHaveBeenCalledWith(errorPayload);
+    });
+
+    test('Restores native event forwarding after unload()', () => {
+      const params = createInitParams();
+      player.init(params);
+      loadDashTrack();
+      player.unload();
+      const nativeWrapped = nativeMock.init.mock.calls[0][0];
+      const dashWrapped = dashMock.init.mock.calls[0][0];
+
+      nativeWrapped.onEnded();
+      expect(params.onEnded).toHaveBeenCalledTimes(1);
+      dashWrapped.onEnded();
+      expect(params.onEnded).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/js/services/plexTranspose.test.ts
+++ b/src/js/services/plexTranspose.test.ts
@@ -1,0 +1,690 @@
+// Generated using Claude Code
+
+import {
+  transposeAllUsersArray,
+  transposeUserData,
+  transposeServerArray,
+  transposeLibraryArray,
+  transposeArtistArray,
+  transposeArtistDetails,
+  transposeArtistRelatedArray,
+  transposeArtistAppearanceAlbumIdsArray,
+  transposeAlbumArray,
+  transposeAlbumDetails,
+  transposeFolderArray,
+  transposePlaylistArray,
+  transposePlaylistDetails,
+  transposeCollectionArray,
+  transposeCollectionItemArray,
+  transposeTagArray,
+  transposeTagItemArray,
+  transposeTrackArray,
+  transposeSearchResultsArray,
+} from './plexTranspose';
+import {
+  PLEX_ALBUMS_RESPONSE,
+  PLEX_ALL_USERS_RESPONSE,
+  PLEX_ARTIST_RELATED_RESPONSE,
+  PLEX_ARTISTS_RESPONSE,
+  PLEX_COLLECTIONS_RESPONSE,
+  PLEX_EMPTY_RESPONSE,
+  PLEX_FOLDER_TRACKS_RESPONSE,
+  PLEX_FOLDERS_RESPONSE,
+  PLEX_LIBRARIES_RESPONSE,
+  PLEX_PLAYLISTS_RESPONSE,
+  PLEX_RESOURCES_RESPONSE,
+  PLEX_SEARCH_RESPONSE,
+  PLEX_TAGS_RESPONSE,
+  PLEX_TRACKS_RESPONSE,
+  PLEX_USER_RESPONSE,
+} from './__fixtures__/plexResponses';
+
+// ======================================================================
+// SHARED TEST VALUES
+// ======================================================================
+
+const libraryId = '20';
+const serverBaseUrl = 'https://plex.example.com:32400';
+const accessToken = 'test-plex-token';
+const timeStamp = 1000;
+
+// Expected photo transcode URLs, as built by getThumb in plexTranspose.js
+const thumb200Sm = `${serverBaseUrl}/photo/:/transcode?width=360&height=360&url=%2Flibrary%2Fmetadata%2F200%2Fthumb%2F1712345678&minSize=1&X-Plex-Token=${accessToken}`;
+const thumb200Md = `${serverBaseUrl}/photo/:/transcode?width=680&height=680&url=%2Flibrary%2Fmetadata%2F200%2Fthumb%2F1712345678&minSize=1&X-Plex-Token=${accessToken}`;
+const thumb100Sm = `${serverBaseUrl}/photo/:/transcode?width=360&height=360&url=%2Flibrary%2Fmetadata%2F100%2Fthumb%2F1711111111&minSize=1&X-Plex-Token=${accessToken}`;
+const thumb100Md = `${serverBaseUrl}/photo/:/transcode?width=680&height=680&url=%2Flibrary%2Fmetadata%2F100%2Fthumb%2F1711111111&minSize=1&X-Plex-Token=${accessToken}`;
+
+// ======================================================================
+// ALL USERS
+// ======================================================================
+
+describe('Testing "transposeAllUsersArray" function', () => {
+  test('Transposes all user fields', () => {
+    const users = transposeAllUsersArray(PLEX_ALL_USERS_RESPONSE);
+    expect(users).toHaveLength(2);
+    expect(users[0]).toStrictEqual({
+      admin: true,
+      displayName: 'Adam',
+      email: 'adam@example.com',
+      guest: false,
+      pinProtected: true,
+      restrictionProfile: undefined,
+      thumbSm: 'https://plex.tv/users/uuid-adam/avatar?c=1712345678',
+      userId: 111,
+      uuid: 'uuid-adam',
+    });
+  });
+
+  test('Falls back to the username when the title is empty', () => {
+    const users = transposeAllUsersArray(PLEX_ALL_USERS_RESPONSE);
+    expect(users[1].displayName).toBe('kiddo');
+    expect(users[1].restrictionProfile).toBe('little_kid');
+  });
+
+  test('Returns an empty array for missing input', () => {
+    expect(transposeAllUsersArray(undefined)).toEqual([]);
+    expect(transposeAllUsersArray({ data: {} })).toEqual([]);
+  });
+});
+
+// ======================================================================
+// USER
+// ======================================================================
+
+describe('Testing "transposeUserData" function', () => {
+  test('Transposes user fields', () => {
+    expect(transposeUserData(PLEX_USER_RESPONSE)).toStrictEqual({
+      displayName: 'Adam',
+      email: 'adam@example.com',
+      thumbSm: 'https://plex.tv/users/uuid-adam/avatar?c=1712345678',
+      userId: 111,
+    });
+  });
+
+  test('Falls back to the username when the title is missing', () => {
+    const user = transposeUserData({ data: { id: 5, username: 'nobody' } });
+    expect(user.displayName).toBe('nobody');
+  });
+});
+
+// ======================================================================
+// SERVERS
+// ======================================================================
+
+describe('Testing "transposeServerArray" function', () => {
+  test('Returns only resources that provide a server', () => {
+    const servers = transposeServerArray(PLEX_RESOURCES_RESPONSE);
+    expect(servers).toHaveLength(2);
+    expect(servers[0]).toStrictEqual({
+      serverId: 'abc123',
+      name: 'Home Server',
+      accessToken: 'server-token-1',
+      connections: [
+        {
+          protocol: 'https',
+          address: '192.168.1.10',
+          port: 32400,
+          uri: 'https://192-168-1-10.abc123.plex.direct:32400',
+          local: true,
+        },
+      ],
+    });
+  });
+
+  test('Falls back to a default name when the server has none', () => {
+    const servers = transposeServerArray(PLEX_RESOURCES_RESPONSE);
+    expect(servers[1].name).toBe('Unknown Plex Server');
+    expect(servers[1].serverId).toBe('def456');
+  });
+
+  test('Returns an empty array for missing input', () => {
+    expect(transposeServerArray(undefined)).toEqual([]);
+    expect(transposeServerArray({ data: undefined })).toEqual([]);
+  });
+});
+
+// ======================================================================
+// LIBRARIES
+// ======================================================================
+
+describe('Testing "transposeLibraryArray" function', () => {
+  test('Returns only music (artist) libraries', () => {
+    expect(transposeLibraryArray(PLEX_LIBRARIES_RESPONSE)).toStrictEqual([
+      { libraryId: '20', title: 'Music' },
+      { libraryId: '21', title: 'Classical' },
+    ]);
+  });
+
+  test('Returns undefined for missing input', () => {
+    // Note: unlike the other transpose functions, there is no `|| []` fallback here
+    expect(transposeLibraryArray(undefined)).toBeUndefined();
+    expect(transposeLibraryArray(PLEX_EMPTY_RESPONSE)).toBeUndefined();
+  });
+});
+
+// ======================================================================
+// ARTISTS
+// ======================================================================
+
+describe('Testing "transposeArtistArray" function', () => {
+  test('Transposes an artist with full field mapping', () => {
+    const artists = transposeArtistArray(PLEX_ARTISTS_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    expect(artists).toHaveLength(2);
+    expect(artists[0]).toStrictEqual({
+      kind: 'artist',
+      libraryId: '20',
+      artistId: '100',
+      title: 'The Static Charms',
+      genre: 'Electronic',
+      country: 'United Kingdom',
+      addedAt: 1680000000,
+      lastPlayed: 1711000000,
+      userRating: 8,
+      isFavourite: false,
+      link: '/libraries/20/artists/100',
+      thumbSm: thumb100Sm,
+      thumbMd: thumb100Md,
+    });
+  });
+
+  test('Handles artists with missing optional fields', () => {
+    const artists = transposeArtistArray(PLEX_ARTISTS_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    expect(artists[1].genre).toBeUndefined();
+    expect(artists[1].country).toBeUndefined();
+    expect(artists[1].thumbSm).toBeNull();
+    expect(artists[1].thumbMd).toBeNull();
+  });
+
+  test('Returns an empty array for missing or empty input', () => {
+    expect(transposeArtistArray(undefined, libraryId, serverBaseUrl, accessToken)).toEqual([]);
+    expect(transposeArtistArray(PLEX_EMPTY_RESPONSE, libraryId, serverBaseUrl, accessToken)).toEqual([]);
+  });
+});
+
+describe('Testing "transposeArtistDetails" function', () => {
+  test('Transposes the first metadata entry', () => {
+    const artist = transposeArtistDetails(PLEX_ARTISTS_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    expect(artist.artistId).toBe('100');
+    expect(artist).toEqual(transposeArtistArray(PLEX_ARTISTS_RESPONSE, libraryId, serverBaseUrl, accessToken)[0]);
+  });
+});
+
+describe('Testing "transposeArtistRelatedArray" function', () => {
+  test('Includes only album hubs with metadata and an artist-albums context', () => {
+    const related = transposeArtistRelatedArray(PLEX_ARTIST_RELATED_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    expect(related).toHaveLength(2);
+    expect(related[0].title).toBe('Albums');
+    expect(related[1].title).toBe('Live Albums, Singles & EPs');
+    // Hub entries are transposed as albums
+    expect(related[0].related).toEqual([
+      transposeAlbumArray(PLEX_ALBUMS_RESPONSE, libraryId, serverBaseUrl, accessToken)[0],
+    ]);
+    expect(related[1].related[0].albumId).toBe('210');
+    expect(related[1].related[0].link).toBe('/libraries/20/albums/210');
+  });
+
+  test('Returns an empty array for missing input', () => {
+    expect(transposeArtistRelatedArray(undefined, libraryId, serverBaseUrl, accessToken)).toEqual([]);
+  });
+});
+
+describe('Testing "transposeArtistAppearanceAlbumIdsArray" function', () => {
+  test('Returns unique album IDs from the track list', () => {
+    const albumIds = transposeArtistAppearanceAlbumIdsArray(
+      PLEX_TRACKS_RESPONSE,
+      libraryId,
+      serverBaseUrl,
+      accessToken
+    );
+    expect(albumIds).toEqual(['200', '201', '202']);
+  });
+
+  test('Returns an empty array for missing input', () => {
+    expect(transposeArtistAppearanceAlbumIdsArray(undefined, libraryId, serverBaseUrl, accessToken)).toEqual([]);
+  });
+});
+
+// ======================================================================
+// ALBUMS
+// ======================================================================
+
+describe('Testing "transposeAlbumArray" function', () => {
+  test('Transposes an album with full field mapping', () => {
+    const albums = transposeAlbumArray(PLEX_ALBUMS_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    expect(albums).toHaveLength(2);
+    expect(albums[0]).toStrictEqual({
+      kind: 'album',
+      libraryId: '20',
+      albumId: '200',
+      title: 'Electric Nights',
+      artist: 'The Static Charms',
+      artistId: '100',
+      artistLink: '/libraries/20/artists/100',
+      genre: 'Electronic',
+      addedAt: 1700000001,
+      lastPlayed: 1712000001,
+      userRating: 9,
+      isFavourite: false,
+      releaseDate: '2020-05-15',
+      link: '/libraries/20/albums/200',
+      thumbSm: thumb200Sm,
+      thumbMd: thumb200Md,
+    });
+  });
+
+  test('Handles albums with missing optional fields', () => {
+    const albums = transposeAlbumArray(PLEX_ALBUMS_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    expect(albums[1].genre).toBeUndefined();
+    expect(albums[1].releaseDate).toBeUndefined();
+    expect(albums[1].userRating).toBeUndefined();
+    expect(albums[1].thumbSm).toBeNull();
+    expect(albums[1].thumbMd).toBeNull();
+  });
+
+  test('Returns an empty array for missing or empty input', () => {
+    expect(transposeAlbumArray(undefined, libraryId, serverBaseUrl, accessToken)).toEqual([]);
+    expect(transposeAlbumArray(PLEX_EMPTY_RESPONSE, libraryId, serverBaseUrl, accessToken)).toEqual([]);
+  });
+});
+
+describe('Testing "transposeAlbumDetails" function', () => {
+  test('Transposes the first metadata entry', () => {
+    const album = transposeAlbumDetails(PLEX_ALBUMS_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    expect(album.albumId).toBe('200');
+    expect(album).toEqual(transposeAlbumArray(PLEX_ALBUMS_RESPONSE, libraryId, serverBaseUrl, accessToken)[0]);
+  });
+});
+
+// ======================================================================
+// FOLDERS
+// ======================================================================
+
+describe('Testing "transposeFolderArray" function', () => {
+  test('Transposes folder rows and derives folderId from the parent key', () => {
+    const items = transposeFolderArray(PLEX_FOLDERS_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    expect(items[1]).toStrictEqual({
+      kind: 'aaafolder',
+      libraryId: '20',
+      folderId: '42',
+      title: 'Zeta Sessions',
+      link: '/libraries/20/folders/42',
+      sortOrder: 1,
+    });
+  });
+
+  test('Excludes non-track metadata rows and keeps folder rows in API order', () => {
+    const items = transposeFolderArray(PLEX_FOLDERS_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    // The 'Stray Album Row' entry (ratingKey present, type !== 'track') is dropped.
+    // The sort comparator checks for kind 'folder' but folders are kind 'aaafolder',
+    // so folder rows keep their API order and are not moved above tracks here.
+    expect(items).toHaveLength(3);
+    expect(items.map((item: { title: string }) => item.title)).toEqual([
+      'Rehearsal Take',
+      'Zeta Sessions',
+      'Alpha Takes',
+    ]);
+    expect(items[0].kind).toBe('track');
+    expect(items[0].trackSortOrder).toBe(0);
+  });
+
+  test('Sorts tracks by album, then disc number, then track number, and assigns sort orders', () => {
+    const items = transposeFolderArray(PLEX_FOLDER_TRACKS_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    expect(items.map((item: { title: string }) => item.title)).toEqual([
+      'First Disc Opener',
+      'First Disc Closer',
+      'Second Disc Opener',
+      'Late Album Opener',
+    ]);
+    expect(items.map((item: { sortOrder: number }) => item.sortOrder)).toEqual([0, 1, 2, 3]);
+    expect(items.map((item: { trackSortOrder: number }) => item.trackSortOrder)).toEqual([0, 1, 2, 3]);
+  });
+
+  test('Returns an empty array for missing input', () => {
+    expect(transposeFolderArray(undefined, libraryId, serverBaseUrl, accessToken)).toEqual([]);
+  });
+});
+
+// ======================================================================
+// PLAYLISTS
+// ======================================================================
+
+describe('Testing "transposePlaylistArray" function', () => {
+  test('Transposes a playlist with full field mapping, preferring the thumb over the composite', () => {
+    const playlists = transposePlaylistArray(
+      PLEX_PLAYLISTS_RESPONSE,
+      libraryId,
+      serverBaseUrl,
+      accessToken,
+      timeStamp,
+      {}
+    );
+    expect(playlists).toHaveLength(4);
+    expect(playlists[0]).toStrictEqual({
+      kind: 'playlist',
+      libraryId: '20',
+      playlistId: '300',
+      title: 'Morning Coffee',
+      addedAt: 1701000000,
+      lastPlayed: 1712500000,
+      userRating: 10,
+      isFavourite: false,
+      link: '/libraries/20/playlists/300',
+      totalTracks: 25,
+      duration: 5400000,
+      thumbSm: `${serverBaseUrl}/photo/:/transcode?width=360&height=360&url=%2Flibrary%2Fmetadata%2F300%2Fthumb%2F1712000000&minSize=1&X-Plex-Token=${accessToken}`,
+      thumbMd: `${serverBaseUrl}/photo/:/transcode?width=680&height=680&url=%2Flibrary%2Fmetadata%2F300%2Fthumb%2F1712000000&minSize=1&X-Plex-Token=${accessToken}`,
+    });
+  });
+
+  test('Replaces the composite URL timestamp with the given timestamp plus playlist edits', () => {
+    const playlists = transposePlaylistArray(
+      PLEX_PLAYLISTS_RESPONSE,
+      libraryId,
+      serverBaseUrl,
+      accessToken,
+      timeStamp,
+      {
+        301: 7,
+      }
+    );
+    // Playlist 301 has an edit count of 7, so its timestamp becomes 1000 + 7
+    expect(playlists[1].thumbSm).toBe(
+      `${serverBaseUrl}/photo/:/transcode?width=360&height=360&url=%2Flibrary%2Fplaylists%2F301%2Fcomposite%2F1007&minSize=1&X-Plex-Token=${accessToken}`
+    );
+    // Playlist 302 has no edits and trailing slashes on its composite URL
+    expect(playlists[2].thumbSm).toContain('url=%2Flibrary%2Fplaylists%2F302%2Fcomposite%2F1000&');
+  });
+
+  test('Returns null thumbs when there is no thumb or composite', () => {
+    const playlists = transposePlaylistArray(
+      PLEX_PLAYLISTS_RESPONSE,
+      libraryId,
+      serverBaseUrl,
+      accessToken,
+      timeStamp,
+      {}
+    );
+    expect(playlists[3].thumbSm).toBeNull();
+    expect(playlists[3].thumbMd).toBeNull();
+  });
+
+  test('Returns an empty array for missing or empty input', () => {
+    expect(transposePlaylistArray(undefined, libraryId, serverBaseUrl, accessToken, timeStamp, {})).toEqual([]);
+    expect(transposePlaylistArray(PLEX_EMPTY_RESPONSE, libraryId, serverBaseUrl, accessToken, timeStamp, {})).toEqual(
+      []
+    );
+  });
+});
+
+describe('Testing "transposePlaylistDetails" function', () => {
+  test('Transposes the first metadata entry', () => {
+    const playlist = transposePlaylistDetails(
+      PLEX_PLAYLISTS_RESPONSE,
+      libraryId,
+      serverBaseUrl,
+      accessToken,
+      timeStamp
+    );
+    expect(playlist.playlistId).toBe('300');
+    expect(playlist.totalTracks).toBe(25);
+    expect(playlist).toEqual(
+      transposePlaylistArray(PLEX_PLAYLISTS_RESPONSE, libraryId, serverBaseUrl, accessToken, timeStamp, {})[0]
+    );
+  });
+});
+
+// ======================================================================
+// COLLECTIONS
+// ======================================================================
+
+describe('Testing "transposeCollectionArray" function', () => {
+  test('Splits collections into artist and album collections', () => {
+    const collections = transposeCollectionArray(PLEX_COLLECTIONS_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    expect(collections.allArtistCollections).toHaveLength(1);
+    expect(collections.allAlbumCollections).toHaveLength(1);
+    expect(collections.allArtistCollections[0]).toStrictEqual({
+      kind: 'collection',
+      libraryId: '20',
+      collectionId: '400',
+      title: 'Favourite Artists',
+      addedAt: 1699000000,
+      userRating: 7,
+      type: 'artist',
+      link: '/libraries/20/artist-collections/400',
+      thumbSm: `${serverBaseUrl}/photo/:/transcode?width=360&height=360&url=%2Flibrary%2Fcollections%2F400%2Fthumb%2F1712345000&minSize=1&X-Plex-Token=${accessToken}`,
+      thumbMd: `${serverBaseUrl}/photo/:/transcode?width=680&height=680&url=%2Flibrary%2Fcollections%2F400%2Fthumb%2F1712345000&minSize=1&X-Plex-Token=${accessToken}`,
+    });
+  });
+
+  test('Falls back to the composite image when a collection has no thumb', () => {
+    const collections = transposeCollectionArray(PLEX_COLLECTIONS_RESPONSE, libraryId, serverBaseUrl, accessToken);
+    expect(collections.allAlbumCollections[0].type).toBe('album');
+    expect(collections.allAlbumCollections[0].link).toBe('/libraries/20/album-collections/401');
+    expect(collections.allAlbumCollections[0].thumbSm).toContain(
+      'url=%2Flibrary%2Fcollections%2F401%2Fcomposite%2F1712345600&'
+    );
+  });
+
+  test('Returns empty arrays for missing input', () => {
+    expect(transposeCollectionArray(undefined, libraryId, serverBaseUrl, accessToken)).toEqual({
+      allArtistCollections: [],
+      allAlbumCollections: [],
+    });
+  });
+});
+
+describe('Testing "transposeCollectionItemArray" function', () => {
+  test('Transposes collection items using the type key', () => {
+    expect(transposeCollectionItemArray(PLEX_ALBUMS_RESPONSE, libraryId, serverBaseUrl, accessToken, 'Album')).toEqual(
+      transposeAlbumArray(PLEX_ALBUMS_RESPONSE, libraryId, serverBaseUrl, accessToken)
+    );
+    expect(
+      transposeCollectionItemArray(PLEX_ARTISTS_RESPONSE, libraryId, serverBaseUrl, accessToken, 'Artist')
+    ).toEqual(transposeArtistArray(PLEX_ARTISTS_RESPONSE, libraryId, serverBaseUrl, accessToken));
+  });
+});
+
+// ======================================================================
+// TAGS
+// ======================================================================
+
+describe('Testing "transposeTagArray" function', () => {
+  test('Transposes genre tags and replaces slashes in titles', () => {
+    expect(transposeTagArray(PLEX_TAGS_RESPONSE, libraryId, 'AlbumGenres')).toStrictEqual([
+      { kind: 'genre', libraryId: '20', genreId: '9001', title: 'Rock & Pop', link: '/libraries/20/album-genres/9001' },
+      { kind: 'genre', libraryId: '20', genreId: '9002', title: 'Jazz', link: '/libraries/20/album-genres/9002' },
+    ]);
+  });
+
+  test('Builds mood and style links from the type key', () => {
+    const moods = transposeTagArray(PLEX_TAGS_RESPONSE, libraryId, 'ArtistMoods');
+    expect(moods[0].kind).toBe('mood');
+    expect(moods[0].moodId).toBe('9001');
+    expect(moods[0].link).toBe('/libraries/20/artist-moods/9001');
+
+    const styles = transposeTagArray(PLEX_TAGS_RESPONSE, libraryId, 'ArtistStyles');
+    expect(styles[0].kind).toBe('style');
+    expect(styles[0].styleId).toBe('9001');
+    expect(styles[0].link).toBe('/libraries/20/artist-styles/9001');
+  });
+
+  test('Returns an empty array for missing input', () => {
+    expect(transposeTagArray(undefined, libraryId, 'AlbumGenres')).toEqual([]);
+  });
+});
+
+describe('Testing "transposeTagItemArray" function', () => {
+  test('Transposes tag items using the type key', () => {
+    expect(
+      transposeTagItemArray(PLEX_ALBUMS_RESPONSE, libraryId, serverBaseUrl, accessToken, 'AlbumGenreItems')
+    ).toEqual(transposeAlbumArray(PLEX_ALBUMS_RESPONSE, libraryId, serverBaseUrl, accessToken));
+    expect(
+      transposeTagItemArray(PLEX_ARTISTS_RESPONSE, libraryId, serverBaseUrl, accessToken, 'ArtistMoodItems')
+    ).toEqual(transposeArtistArray(PLEX_ARTISTS_RESPONSE, libraryId, serverBaseUrl, accessToken));
+  });
+});
+
+// ======================================================================
+// TRACKS
+// ======================================================================
+
+describe('Testing "transposeTrackArray" function', () => {
+  const tracks = transposeTrackArray(PLEX_TRACKS_RESPONSE, libraryId, serverBaseUrl, accessToken);
+
+  test('Transposes a standard track with full field mapping', () => {
+    expect(tracks).toHaveLength(4);
+    expect(tracks[0]).toStrictEqual({
+      kind: 'track',
+      libraryId: '20',
+      trackId: '5001',
+      trackKey: '/library/metadata/5001',
+      playlistItemID: undefined,
+      title: 'Opening Theme',
+      artist: 'The Static Charms',
+      artistLink: '/libraries/20/artists/100',
+      album: 'Electric Nights',
+      albumId: '200',
+      albumLink: '/libraries/20/albums/200',
+      trackNumber: 1,
+      discNumber: 1,
+      codec: 'flac',
+      bitrate: 1043,
+      duration: 215000,
+      userRating: 10,
+      releaseDate: '2020-01-01',
+      thumbSm: thumb200Sm,
+      thumbMd: thumb200Md,
+      src: `${serverBaseUrl}/library/parts/9001/1650000001/file.flac?X-Plex-Token=${accessToken}`,
+    });
+  });
+
+  test('Builds the src URL from the server base URL, first media part key and access token', () => {
+    expect(tracks[1].src).toBe(`${serverBaseUrl}/library/parts/9002/1650000002/file.wma?X-Plex-Token=${accessToken}`);
+    expect(tracks[3].src).toBe(`${serverBaseUrl}/library/parts/9004/1650000004/file.aiff?X-Plex-Token=${accessToken}`);
+  });
+
+  test('Uses originalTitle as the artist with no artist link for appearance tracks', () => {
+    // originalTitle differs from grandparentTitle — likely an appearance
+    expect(tracks[1].artist).toBe('The Featured Act');
+    expect(tracks[1].artistLink).toBeNull();
+    // originalTitle matches grandparentTitle — treated as the album artist
+    expect(tracks[2].artist).toBe('The Static Charms');
+    expect(tracks[2].artistLink).toBe('/libraries/20/artists/100');
+  });
+
+  test('Maps codecs for display: wmav2 becomes wma and pcm uses the container', () => {
+    expect(tracks.map((track: { codec: string }) => track.codec)).toEqual(['flac', 'wma', 'wav', 'aiff']);
+  });
+
+  test('Builds thumb URLs via the photo transcode endpoint and strips existing query params', () => {
+    expect(tracks[0].thumbSm).toBe(thumb200Sm);
+    expect(tracks[0].thumbMd).toBe(thumb200Md);
+    // Track 3's raw thumb carries a stale query string, which is stripped before encoding
+    expect(tracks[2].thumbSm).toBe(thumb200Sm);
+    expect(tracks[2].thumbSm).not.toContain('stale-token');
+  });
+
+  test('Returns null thumbs when a track has no thumb', () => {
+    expect(tracks[1].thumbSm).toBeNull();
+    expect(tracks[1].thumbMd).toBeNull();
+  });
+
+  test('Derives releaseDate from parentYear', () => {
+    expect(tracks[0].releaseDate).toBe('2020-01-01');
+    expect(tracks[3].releaseDate).toBe('1974-01-01');
+    expect(tracks[1].releaseDate).toBeNull();
+  });
+
+  test('Maps playlistItemID when present', () => {
+    expect(tracks[3].playlistItemID).toBe(90004);
+    expect(tracks[0].playlistItemID).toBeUndefined();
+  });
+
+  test('Returns an empty array for missing or empty input', () => {
+    expect(transposeTrackArray(undefined, libraryId, serverBaseUrl, accessToken)).toEqual([]);
+    expect(transposeTrackArray(PLEX_EMPTY_RESPONSE, libraryId, serverBaseUrl, accessToken)).toEqual([]);
+  });
+});
+
+// ======================================================================
+// SEARCH RESULTS
+// ======================================================================
+
+describe('Testing "transposeSearchResultsArray" function', () => {
+  const results = transposeSearchResultsArray(PLEX_SEARCH_RESPONSE, libraryId, serverBaseUrl, accessToken);
+
+  test('Sorts results by score, then type order, then title', () => {
+    expect(results.map((result: { title: string }) => result.title)).toEqual([
+      'Electric Nights', // highest score
+      'Analog Archive', // artist, title tiebreak
+      'The Static Charms', // artist, title tiebreak
+      'Deep Focus', // playlist
+      'Best of 2020', // album collection
+      'Opening Theme', // track
+    ]);
+  });
+
+  test('Maps result fields per type', () => {
+    expect(results[0]).toStrictEqual({
+      score: 0.95,
+      albumId: '200',
+      type: 'album',
+      icon: 'PlayCircleIcon',
+      title: 'Electric Nights',
+      link: '/libraries/20/albums/200',
+      thumbSm: thumb200Sm,
+    });
+    expect(results[2]).toStrictEqual({
+      score: 0.9,
+      artistId: '100',
+      type: 'artist',
+      icon: 'PeopleIcon',
+      title: 'The Static Charms',
+      link: '/libraries/20/artists/100',
+      thumbSm: thumb100Sm,
+    });
+    expect(results[3]).toStrictEqual({
+      score: 0.9,
+      playlistId: '301',
+      type: 'playlist',
+      icon: 'PlaylistIcon',
+      title: 'Deep Focus',
+      link: '/libraries/20/playlists/301',
+      thumbSm: `${serverBaseUrl}/photo/:/transcode?width=360&height=360&url=%2Flibrary%2Fplaylists%2F301%2Fcomposite%2F1712345678&minSize=1&X-Plex-Token=${accessToken}`,
+    });
+    expect(results[4]).toStrictEqual({
+      score: 0.9,
+      collectionId: '401',
+      type: 'album collection',
+      icon: 'AlbumCollectionsIcon',
+      title: 'Best of 2020',
+      link: '/libraries/20/album-collections/401',
+      thumbSm: `${serverBaseUrl}/photo/:/transcode?width=360&height=360&url=%2Flibrary%2Fcollections%2F401%2Fcomposite%2F1712345600&minSize=1&X-Plex-Token=${accessToken}`,
+    });
+    expect(results[5]).toStrictEqual({
+      score: 0.9,
+      trackId: '5001',
+      type: 'track',
+      icon: 'MusicNoteSingleIcon',
+      title: 'Opening Theme',
+      // Track results link to their album
+      link: '/libraries/20/albums/200',
+      thumbSm: thumb200Sm,
+    });
+  });
+
+  test('Returns null thumbs for results without a thumb', () => {
+    expect(results[1].artistId).toBe('102');
+    expect(results[1].thumbSm).toBeNull();
+  });
+
+  test('Excludes unsupported result types and hubs without metadata', () => {
+    // The 'photo' result and the empty 'genre' hub are both dropped
+    expect(results).toHaveLength(6);
+    expect(results.map((result: { title: string }) => result.title)).not.toContain('Beach Day');
+  });
+
+  test('Returns an empty array for missing input', () => {
+    expect(transposeSearchResultsArray(undefined, libraryId, serverBaseUrl, accessToken)).toEqual([]);
+  });
+});

--- a/src/js/store/__fixtures__/playerSession.ts
+++ b/src/js/store/__fixtures__/playerSession.ts
@@ -1,0 +1,59 @@
+// Generated using Claude Code
+
+// A small fake track list matching the internal normalised track shape.
+// Only the fields read by models.player.js are included. No trackKey is set,
+// so the Plex DASH helper (withDashSrc) leaves each track untouched and
+// playerX.loadTrack receives these exact objects.
+export const TRACKS = [
+  {
+    trackId: 'track-1',
+    title: 'Track One',
+    artist: 'Artist One',
+    src: 'https://server.local/tracks/1.mp3',
+    codec: 'mp3',
+  },
+  {
+    trackId: 'track-2',
+    title: 'Track Two',
+    artist: 'Artist One',
+    src: 'https://server.local/tracks/2.mp3',
+    codec: 'mp3',
+  },
+  {
+    trackId: 'track-3',
+    title: 'Track Three',
+    artist: 'Artist Two',
+    src: 'https://server.local/tracks/3.mp3',
+    codec: 'mp3',
+  },
+  {
+    trackId: 'track-4',
+    title: 'Track Four',
+    artist: 'Artist Two',
+    src: 'https://server.local/tracks/4.mp3',
+    codec: 'mp3',
+  },
+  {
+    trackId: 'track-5',
+    title: 'Track Five',
+    artist: 'Artist Three',
+    src: 'https://server.local/tracks/5.mp3',
+    codec: 'mp3',
+  },
+];
+
+// Baseline "queue loaded, idle at track 0" playing state — spread into
+// sessionModel.setSessionState and overridden per test.
+export const basePlayingSession = {
+  playingTrackList: TRACKS,
+  playingTrackKeys: [0, 1, 2, 3, 4],
+  playingTrackIndex: 0,
+  playingTrackCount: TRACKS.length,
+  playingTrackProgress: 0,
+  playingOrder: null,
+  playingRepeatAll: false,
+  playingRepeatOnce: false,
+  playingShuffle: false,
+  volumeLevel: 50,
+  volumeMuted: false,
+};

--- a/src/js/store/models.player.test.ts
+++ b/src/js/store/models.player.test.ts
@@ -1,0 +1,536 @@
+// Generated using Claude Code
+
+// Scope: playback controls, queue navigation (next/prev/repeat/shuffle),
+// volume handling, and the loadTrack error contract — driven through a real
+// Rematch store with only the service boundaries mocked. Deliberately out of
+// scope (candidates for a future suite): the LOAD TRACKS family
+// (playerLoadArtist/Album/Playlist/Folder/TrackItem/TrackList — async
+// bridge-fetch flows), the error effects (playerError/playerErrorPlayback/
+// playerErrorNext — setTimeout + MediaError dependent), playerRefresh's
+// credential retry loop, and playerLogQuit.
+
+import { init } from '@rematch/core';
+
+import { appModel } from './models.app';
+import { playerModel } from './models.player';
+import { sessionModel } from './models.session';
+import { basePlayingSession, TRACKS } from './__fixtures__/playerSession';
+import * as playerX from 'js/services/player';
+import * as bridge from 'js/services/bridge';
+import { analyticsEvent } from 'js/utils';
+
+// ======================================================================
+// MOCKS
+// ======================================================================
+
+// models.player.js drives playback through the playerX service — mocked so
+// tests can assert the calls without touching audio elements.
+vi.mock('js/services/player', () => ({
+  init: vi.fn(),
+  unload: vi.fn(),
+  loadTrack: vi.fn(() => true),
+  pause: vi.fn(),
+  resume: vi.fn(),
+  restart: vi.fn(),
+  setProgress: vi.fn(),
+  getCurrentProgress: vi.fn(() => 0),
+  setVolume: vi.fn(),
+}));
+
+// Every bridge function referenced by the three models under test, so no
+// effect can accidentally hit the network.
+vi.mock('js/services/bridge', () => ({
+  // models.player.js
+  logPlaybackPlay: vi.fn(),
+  logPlaybackProgress: vi.fn(),
+  logPlaybackPause: vi.fn(),
+  logPlaybackStop: vi.fn(),
+  logPlaybackQuit: vi.fn(),
+  getAllArtistTracks: vi.fn(),
+  getAlbumTracks: vi.fn(),
+  getPlaylistTracks: vi.fn(),
+  getFolderItems: vi.fn(),
+  // models.app.js
+  init: vi.fn(),
+  plexLogin: vi.fn(),
+  logout: vi.fn(),
+  getAllUsers: vi.fn(),
+  getAllServers: vi.fn(),
+  getUserInfo: vi.fn(),
+  getAllPlaylists: vi.fn(),
+  // models.session.js
+  switchUser: vi.fn(),
+  abortAllRequests: vi.fn(),
+  getAllLibraries: vi.fn(),
+}));
+
+// The components barrel pulls in JSX and SCSS that cannot be imported in a
+// test run — only PlaybackErrorMessage is used by models.player.js.
+vi.mock('js/components', () => ({
+  PlaybackErrorMessage: vi.fn(() => 'error message'),
+}));
+
+// Keep the real utils (getTrackKeys, requiresTranscoding, sortList, etc.) but
+// stub the analytics call so tests can assert the tracked event names.
+vi.mock('js/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('js/utils')>();
+  return {
+    ...actual,
+    analyticsEvent: vi.fn(),
+  };
+});
+
+// ======================================================================
+// SETUP
+// ======================================================================
+
+// Mirrors store.ts, which types the store as `any` until the models are
+// converted to TypeScript.
+type Store = any;
+
+let store: Store;
+
+// Seeds the playing session state; overrides are merged over the baseline.
+const seedSession = (overrides: Record<string, unknown> = {}) => {
+  store.dispatch.sessionModel.setSessionState({ ...basePlayingSession, ...overrides });
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(playerX.loadTrack).mockReturnValue(true);
+  vi.mocked(playerX.getCurrentProgress).mockReturnValue(0);
+  // A real Rematch store with the real models, so effects dispatch into real
+  // reducers and cross-model state transitions can be asserted.
+  store = init({ models: { appModel, playerModel, sessionModel } });
+  store.dispatch.appModel.setAppState({ currentService: 'plex' });
+  seedSession();
+});
+
+// ======================================================================
+// TESTS
+// ======================================================================
+
+describe('Testing "playerModel" store effects', () => {
+  //
+  // INITIALISE
+  //
+
+  describe('playerInit', () => {
+    // playerInit registers a window beforeunload listener bound to the store
+    // created for that test — swallow the registrations so listeners don't
+    // accumulate on the shared jsdom window across tests.
+    let addEventListenerSpy: ReturnType<typeof vi.spyOn>;
+    beforeEach(() => {
+      addEventListenerSpy = vi.spyOn(window, 'addEventListener').mockImplementation(() => undefined);
+    });
+    afterEach(() => {
+      addEventListenerSpy.mockRestore();
+    });
+
+    test('Initialises the player with the saved volume state and marks it inited', () => {
+      seedSession({ volumeLevel: 40, volumeMuted: true });
+      store.dispatch.playerModel.playerInit();
+
+      expect(playerX.init).toHaveBeenCalledTimes(1);
+      expect(playerX.init).toHaveBeenCalledWith(
+        expect.objectContaining({
+          volumeLevel: 40,
+          volumeMuted: true,
+          onLoadStart: expect.any(Function),
+          onCanPlay: expect.any(Function),
+          onEnded: expect.any(Function),
+          onError: expect.any(Function),
+        })
+      );
+      expect(store.getState().playerModel.playerInited).toBe(true);
+    });
+
+    test('Auto-advances to the next track when the player reports the track has ended', () => {
+      seedSession({ playingTrackIndex: 1 });
+      store.dispatch.playerModel.playerInit();
+
+      const { onEnded } = vi.mocked(playerX.init).mock.calls[0][0];
+      onEnded();
+
+      // ended -> playerNext(true) -> load the next track and play it
+      expect(playerX.loadTrack).toHaveBeenCalledWith(TRACKS[2], undefined, true);
+      expect(store.getState().sessionModel.playingTrackIndex).toBe(2);
+      expect(analyticsEvent).toHaveBeenCalledWith('Plex / Music / Next Track (Auto)');
+    });
+  });
+
+  describe('playerUnload', () => {
+    test('Stops playback, clears the loaded track, and unloads the player', () => {
+      store.dispatch.playerModel.setPlayerState({ playerPlaying: true, playerTrackLoaded: true });
+      store.dispatch.playerModel.playerUnload();
+
+      const state = store.getState().playerModel;
+      expect(state.playerPlaying).toBe(false);
+      expect(state.playerTrackLoaded).toBe(false);
+      expect(playerX.unload).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  //
+  // LOAD TRACKS
+  //
+
+  describe('playerLoadIndex', () => {
+    test('Loads the track at the given index and starts playback', () => {
+      store.dispatch.playerModel.playerLoadIndex({ index: 1, play: true, progress: 30 });
+
+      expect(playerX.loadTrack).toHaveBeenCalledWith(TRACKS[1], 30, true);
+      const state = store.getState();
+      expect(state.playerModel.playerPlaying).toBe(true);
+      expect(state.playerModel.playerTrackLoaded).toBe(true);
+      expect(state.playerModel.playerTrackError).toBe(false);
+      expect(state.sessionModel.playingTrackIndex).toBe(1);
+      expect(bridge.logPlaybackPlay).toHaveBeenCalledWith(TRACKS[1], 30);
+      expect(analyticsEvent).toHaveBeenCalledWith('Plex / Music / Play (Track)');
+    });
+
+    test('Loads without playing when play is false', () => {
+      store.dispatch.playerModel.playerLoadIndex({ index: 1, play: false });
+
+      expect(playerX.loadTrack).toHaveBeenCalledWith(TRACKS[1], undefined, false);
+      const state = store.getState();
+      expect(state.playerModel.playerPlaying).toBe(false);
+      expect(state.playerModel.playerTrackLoaded).toBe(true);
+      expect(state.playerModel.playerTrackError).toBe(false);
+      expect(state.sessionModel.playingTrackIndex).toBe(1);
+      expect(bridge.logPlaybackPlay).not.toHaveBeenCalled();
+    });
+
+    test('Flags a track error when the player cannot load the track', () => {
+      vi.mocked(playerX.loadTrack).mockReturnValue(false);
+      store.dispatch.playerModel.playerLoadIndex({ index: 1, play: true });
+
+      const state = store.getState();
+      expect(state.playerModel.playerPlaying).toBe(false);
+      expect(state.playerModel.playerTrackLoaded).toBe(true);
+      expect(state.playerModel.playerTrackError).toBe(true);
+      expect(state.sessionModel.playingTrackIndex).toBe(1);
+    });
+
+    test('Unloads the playing state when the queue cannot be read (legacy pre-shuffle state)', () => {
+      seedSession({ playingTrackKeys: null });
+      store.dispatch.playerModel.playerLoadIndex({ index: 1, play: true });
+
+      // the catch path resets the playing session state entirely
+      expect(playerX.loadTrack).not.toHaveBeenCalled();
+      const state = store.getState().sessionModel;
+      expect(state.playingTrackList).toBe(null);
+      expect(state.playingTrackIndex).toBe(null);
+    });
+  });
+
+  //
+  // PLAYER CONTROLS
+  //
+
+  describe('playerResume', () => {
+    test('Resumes playback and logs the resume to the server', () => {
+      seedSession({ playingTrackIndex: 1, playingTrackProgress: 30 });
+      store.dispatch.playerModel.playerResume();
+
+      expect(playerX.resume).toHaveBeenCalledTimes(1);
+      expect(store.getState().playerModel.playerPlaying).toBe(true);
+      expect(bridge.logPlaybackPlay).toHaveBeenCalledWith(TRACKS[1], 30);
+      expect(analyticsEvent).toHaveBeenCalledWith('Plex / Music / Play (Resume)');
+    });
+
+    test('Reloads the current track instead of resuming after a track error', () => {
+      seedSession({ playingTrackIndex: 1 });
+      store.dispatch.playerModel.setPlayerState({ playerTrackError: true });
+      store.dispatch.playerModel.playerResume();
+
+      expect(playerX.resume).not.toHaveBeenCalled();
+      expect(playerX.loadTrack).toHaveBeenCalledWith(TRACKS[1], undefined, true);
+      const state = store.getState().playerModel;
+      expect(state.playerPlaying).toBe(true);
+      expect(state.playerTrackError).toBe(false);
+    });
+  });
+
+  describe('playerPause', () => {
+    test('Pauses the player and logs the pause when playing', () => {
+      seedSession({ playingTrackIndex: 1, playingTrackProgress: 30 });
+      store.dispatch.playerModel.setPlayerState({ playerPlaying: true });
+      store.dispatch.playerModel.playerPause();
+
+      expect(playerX.pause).toHaveBeenCalledTimes(1);
+      expect(store.getState().playerModel.playerPlaying).toBe(false);
+      expect(bridge.logPlaybackPause).toHaveBeenCalledWith(TRACKS[1], 30);
+      expect(analyticsEvent).toHaveBeenCalledWith('Plex / Music / Pause');
+    });
+
+    test('Still pauses the player but does not log when already paused', () => {
+      store.dispatch.playerModel.playerPause();
+
+      expect(playerX.pause).toHaveBeenCalledTimes(1);
+      expect(bridge.logPlaybackPause).not.toHaveBeenCalled();
+      expect(analyticsEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('playerProgress', () => {
+    test('Stores progress and logs it to the server while playing', () => {
+      seedSession({ playingTrackIndex: 1 });
+      store.dispatch.playerModel.setPlayerState({ playerPlaying: true });
+      store.dispatch.playerModel.playerProgress(120);
+
+      expect(store.getState().sessionModel.playingTrackProgress).toBe(120);
+      expect(bridge.logPlaybackProgress).toHaveBeenCalledWith(TRACKS[1], 120);
+    });
+
+    test('Ignores progress updates while paused', () => {
+      store.dispatch.playerModel.playerProgress(120);
+
+      expect(store.getState().sessionModel.playingTrackProgress).toBe(0);
+      expect(bridge.logPlaybackProgress).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('playerPrev', () => {
+    test('Restarts the current track when progress is greater than 5 seconds', () => {
+      seedSession({ playingTrackIndex: 2 });
+      vi.mocked(playerX.getCurrentProgress).mockReturnValue(42);
+      store.dispatch.playerModel.playerPrev();
+
+      expect(playerX.restart).toHaveBeenCalledTimes(1);
+      expect(playerX.loadTrack).not.toHaveBeenCalled();
+      const state = store.getState();
+      expect(state.sessionModel.playingTrackIndex).toBe(2);
+      expect(state.playerModel.playerPlaying).toBe(true);
+      expect(state.playerModel.playerInteractionCount).toBe(1);
+      expect(analyticsEvent).toHaveBeenCalledWith('Plex / Music / Restart Track');
+    });
+
+    test('Loads the previous track when progress is 5 seconds or less', () => {
+      seedSession({ playingTrackIndex: 2 });
+      vi.mocked(playerX.getCurrentProgress).mockReturnValue(3);
+      store.dispatch.playerModel.playerPrev();
+
+      expect(playerX.restart).not.toHaveBeenCalled();
+      expect(playerX.loadTrack).toHaveBeenCalledWith(TRACKS[1], undefined, true);
+      expect(store.getState().sessionModel.playingTrackIndex).toBe(1);
+      expect(analyticsEvent).toHaveBeenCalledWith('Plex / Music / Previous Track');
+    });
+
+    test('Wraps to the last track when at track 0 with repeat all', () => {
+      seedSession({ playingTrackIndex: 0, playingRepeatAll: true });
+      store.dispatch.playerModel.playerPrev();
+
+      expect(playerX.loadTrack).toHaveBeenCalledWith(TRACKS[4], undefined, true);
+      expect(store.getState().sessionModel.playingTrackIndex).toBe(4);
+      expect(store.getState().playerModel.playerPlaying).toBe(true);
+    });
+
+    test('Restarts the current track when at track 0 without repeat all', () => {
+      seedSession({ playingTrackIndex: 0 });
+      store.dispatch.playerModel.playerPrev();
+
+      expect(playerX.restart).toHaveBeenCalledTimes(1);
+      expect(playerX.loadTrack).not.toHaveBeenCalled();
+      expect(store.getState().sessionModel.playingTrackIndex).toBe(0);
+    });
+  });
+
+  describe('playerNext', () => {
+    test('Manual next advances to the next track and plays it', () => {
+      seedSession({ playingTrackIndex: 1 });
+      store.dispatch.playerModel.playerNext();
+
+      expect(playerX.loadTrack).toHaveBeenCalledTimes(1);
+      expect(playerX.loadTrack).toHaveBeenCalledWith(TRACKS[2], undefined, true);
+      const state = store.getState();
+      expect(state.sessionModel.playingTrackIndex).toBe(2);
+      expect(state.playerModel.playerPlaying).toBe(true);
+      expect(state.playerModel.playerTrackLoaded).toBe(true);
+      expect(state.playerModel.playerTrackError).toBe(false);
+      expect(bridge.logPlaybackPlay).toHaveBeenCalledWith(TRACKS[2], undefined);
+      expect(analyticsEvent).toHaveBeenCalledWith('Plex / Music / Next Track');
+    });
+
+    test('Manual next at the last track without repeat loads track 0 without playing and logs a stop', () => {
+      seedSession({ playingTrackIndex: 4 });
+      store.dispatch.playerModel.playerNext();
+
+      expect(playerX.loadTrack).toHaveBeenCalledWith(TRACKS[0], undefined, false);
+      const state = store.getState();
+      expect(state.sessionModel.playingTrackIndex).toBe(0);
+      expect(state.playerModel.playerPlaying).toBe(false);
+      expect(bridge.logPlaybackStop).toHaveBeenCalledWith(TRACKS[4]);
+      expect(bridge.logPlaybackPlay).not.toHaveBeenCalled();
+    });
+
+    test('Manual next at the last track with repeat all wraps to track 0 and plays it', () => {
+      seedSession({ playingTrackIndex: 4, playingRepeatAll: true });
+      store.dispatch.playerModel.playerNext();
+
+      expect(playerX.loadTrack).toHaveBeenCalledWith(TRACKS[0], undefined, true);
+      const state = store.getState();
+      expect(state.sessionModel.playingTrackIndex).toBe(0);
+      expect(state.playerModel.playerPlaying).toBe(true);
+      expect(bridge.logPlaybackStop).not.toHaveBeenCalled();
+      expect(analyticsEvent).toHaveBeenCalledWith('Plex / Music / Next Track (Restart)');
+    });
+
+    test('Auto next (track ended) with repeat once reloads the same track', () => {
+      seedSession({ playingTrackIndex: 2, playingRepeatOnce: true });
+      store.dispatch.playerModel.playerNext(true);
+
+      expect(playerX.loadTrack).toHaveBeenCalledWith(TRACKS[2], undefined, true);
+      const state = store.getState().sessionModel;
+      expect(state.playingTrackIndex).toBe(2);
+      // repeat once is only cleared when the track index actually changes
+      expect(state.playingRepeatOnce).toBe(true);
+      expect(analyticsEvent).toHaveBeenCalledWith('Plex / Music / Next Track (Repeat Once) (Auto)');
+    });
+
+    test('Manual next with repeat once skips to the next track and reverts repeat once to repeat all', () => {
+      seedSession({ playingTrackIndex: 1, playingRepeatOnce: true });
+      store.dispatch.playerModel.playerNext();
+
+      expect(playerX.loadTrack).toHaveBeenCalledWith(TRACKS[2], undefined, true);
+      const state = store.getState().sessionModel;
+      expect(state.playingTrackIndex).toBe(2);
+      // disableRepeatOnceOnTrackChange (default on) clears repeat once, and
+      // revertRepeatOnceToRepeatAll (default on) re-enables repeat all
+      expect(state.playingRepeatOnce).toBe(false);
+      expect(state.playingRepeatAll).toBe(true);
+    });
+  });
+
+  describe('playerRepeatToggle', () => {
+    test('Cycles repeat from off to all to once to off', () => {
+      // off -> repeat all
+      store.dispatch.playerModel.playerRepeatToggle();
+      let state = store.getState().sessionModel;
+      expect(state.playingRepeatAll).toBe(true);
+      expect(state.playingRepeatOnce).toBe(false);
+      expect(analyticsEvent).toHaveBeenLastCalledWith('Plex / Music / Repeat All');
+
+      // repeat all -> repeat once
+      store.dispatch.playerModel.playerRepeatToggle();
+      state = store.getState().sessionModel;
+      expect(state.playingRepeatAll).toBe(false);
+      expect(state.playingRepeatOnce).toBe(true);
+      expect(analyticsEvent).toHaveBeenLastCalledWith('Plex / Music / Repeat Once');
+
+      // repeat once -> off
+      store.dispatch.playerModel.playerRepeatToggle();
+      state = store.getState().sessionModel;
+      expect(state.playingRepeatAll).toBe(false);
+      expect(state.playingRepeatOnce).toBe(false);
+      expect(analyticsEvent).toHaveBeenLastCalledWith('Plex / Music / Repeat Off');
+    });
+  });
+
+  describe('playerShuffleToggle', () => {
+    test('Shuffle on recomputes the track keys keeping the playing track at the new index', () => {
+      seedSession({ playingTrackIndex: 2 });
+      store.dispatch.playerModel.playerShuffleToggle();
+
+      const state = store.getState().sessionModel;
+      expect(state.playingShuffle).toBe(true);
+      // the new keys are a permutation of all five tracks
+      expect([...state.playingTrackKeys].sort((a: number, b: number) => a - b)).toEqual([0, 1, 2, 3, 4]);
+      // the entry at the new index is still the real track that was playing (real index 2)
+      expect(state.playingTrackKeys[state.playingTrackIndex]).toBe(2);
+      // getTrackKeys pins the playing track to the front of a fresh shuffle
+      expect(state.playingTrackIndex).toBe(0);
+      expect(analyticsEvent).toHaveBeenCalledWith('Plex / Music / Shuffle On');
+    });
+
+    test('Shuffle off restores sequential keys and repositions the playing track', () => {
+      seedSession({ playingShuffle: true, playingTrackKeys: [3, 0, 2, 4, 1], playingTrackIndex: 2 });
+      store.dispatch.playerModel.playerShuffleToggle();
+
+      const state = store.getState().sessionModel;
+      expect(state.playingShuffle).toBe(false);
+      expect(state.playingTrackKeys).toEqual([0, 1, 2, 3, 4]);
+      // real track 2 was playing (keys[2] of the shuffled order) and remains selected
+      expect(state.playingTrackIndex).toBe(2);
+      expect(analyticsEvent).toHaveBeenCalledWith('Plex / Music / Shuffle Off');
+    });
+  });
+
+  //
+  // VOLUME CONTROLS
+  //
+
+  describe('volumeRefresh', () => {
+    test('Applies the saved volume level to the player', () => {
+      seedSession({ volumeLevel: 60, volumeMuted: false });
+      store.dispatch.playerModel.volumeRefresh();
+
+      expect(playerX.setVolume).toHaveBeenCalledWith(60);
+    });
+
+    test('Applies a volume of 0 to the player when muted', () => {
+      seedSession({ volumeLevel: 60, volumeMuted: true });
+      store.dispatch.playerModel.volumeRefresh();
+
+      expect(playerX.setVolume).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe('volumeLevelSet', () => {
+    test('Sets the volume level, unmutes, and updates the player volume', () => {
+      seedSession({ volumeLevel: 10, volumeMuted: true });
+      store.dispatch.playerModel.volumeLevelSet(30);
+
+      const state = store.getState().sessionModel;
+      expect(state.volumeLevel).toBe(30);
+      expect(state.volumeMuted).toBe(false);
+      expect(playerX.setVolume).toHaveBeenCalledWith(30);
+    });
+  });
+
+  describe('volumeMuteToggle', () => {
+    test('Unmutes and restores the default volume when muted at volume 0', () => {
+      seedSession({ volumeMuted: true, volumeLevel: 0 });
+      store.dispatch.playerModel.volumeMuteToggle();
+
+      const state = store.getState().sessionModel;
+      expect(state.volumeLevel).toBe(75);
+      expect(state.volumeMuted).toBe(false);
+      expect(playerX.setVolume).toHaveBeenCalledWith(75);
+      expect(analyticsEvent).toHaveBeenCalledWith('Plex / Music / Mute Off');
+    });
+
+    test('Unmutes and keeps the saved volume when muted at a non-zero volume', () => {
+      seedSession({ volumeMuted: true, volumeLevel: 60 });
+      store.dispatch.playerModel.volumeMuteToggle();
+
+      const state = store.getState().sessionModel;
+      expect(state.volumeLevel).toBe(60);
+      expect(state.volumeMuted).toBe(false);
+      expect(playerX.setVolume).toHaveBeenCalledWith(60);
+      expect(analyticsEvent).toHaveBeenCalledWith('Plex / Music / Mute Off');
+    });
+
+    test('Unmutes and restores the default volume when unmuted at volume 0', () => {
+      seedSession({ volumeMuted: false, volumeLevel: 0 });
+      store.dispatch.playerModel.volumeMuteToggle();
+
+      const state = store.getState().sessionModel;
+      expect(state.volumeLevel).toBe(75);
+      expect(state.volumeMuted).toBe(false);
+      expect(playerX.setVolume).toHaveBeenCalledWith(75);
+      expect(analyticsEvent).toHaveBeenCalledWith('Plex / Music / Mute Off');
+    });
+
+    test('Mutes when unmuted at a non-zero volume', () => {
+      seedSession({ volumeMuted: false, volumeLevel: 60 });
+      store.dispatch.playerModel.volumeMuteToggle();
+
+      const state = store.getState().sessionModel;
+      expect(state.volumeLevel).toBe(60);
+      expect(state.volumeMuted).toBe(true);
+      expect(playerX.setVolume).toHaveBeenCalledWith(0);
+      expect(analyticsEvent).toHaveBeenCalledWith('Plex / Music / Mute On');
+    });
+  });
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -9,3 +9,40 @@ Object.defineProperty(global, 'HTMLAudioElement', {
   writable: true,
   value: MockHTMLAudioElement,
 });
+
+// Node >= 23 enables an experimental Web Storage implementation whose global
+// localStorage/sessionStorage accessors shadow jsdom's in the test environment,
+// and which is non-functional without Node's --localstorage-file flag (methods
+// like clear() are missing). When the storage in the environment is broken,
+// replace it with a functional in-memory implementation. On Node versions
+// where jsdom's storage survives (20/22), this leaves it untouched.
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+  get length(): number {
+    return this.store.size;
+  }
+  key(index: number): string | null {
+    return [...this.store.keys()][index] ?? null;
+  }
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(String(key), String(value));
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+for (const storageKey of ['localStorage', 'sessionStorage'] as const) {
+  if (typeof globalThis[storageKey]?.clear !== 'function') {
+    Object.defineProperty(globalThis, storageKey, {
+      configurable: true,
+      value: new MemoryStorage(),
+    });
+  }
+}


### PR DESCRIPTION
# Expand automated testing: core playback + transpose coverage, CI, Node 23+ fix

Picks up item 3 from the README's "Want to help?" list (automated testing). Everything here is additive — no production source files are touched.

## What's included

**1. Fix the unit test environment on Node ≥ 23** (`vitest.setup.ts`)

Node 23+ enables an experimental Web Storage whose global `localStorage`/`sessionStorage` shadow jsdom's in the vitest environment and are non-functional without a Node flag — so `localStorage.test.ts` fails 11 tests on modern Node (and, since husky runs the test suite pre-commit, commits are blocked entirely). The setup file now installs a functional in-memory Storage only when the environment's storage is broken; Node 20/22 keep using jsdom's real implementation.

**2. New test suites for the untested core** (146 new tests; the suite grows from 274 to 420, all passing)

| Suite | Covers |
| --- | --- |
| `src/js/services/player.test.ts` | The player router: native/DASH routing decisions per codec + dashSrc availability, the credentials-not-ready `false` contract, control routing following the active player, volume fan-out, and the init() callback gating that suppresses stale events from the inactive player |
| `src/js/store/models.player.test.ts` | Playback management effects against a real Rematch store (bridge/player mocked): next/prev incl. repeat-all wrap, repeat-once, restart-after-5s, shuffle re-keying that preserves the playing track, the repeat cycle, the mute state machine, error contracts from `loadTrack`, and playback logging calls |
| `src/js/services/plexTranspose.test.ts` | Plex API normalisation with realistic fixtures: track/album/artist/playlist mapping, appearance-artist logic, codec display rules (pcm→container, wmav2→wma), stream/thumb URL + token construction |
| `src/js/services/jellyTranspose.test.ts` | Jellyfin normalisation with realistic fixtures: field mapping incl. RunTimeTicks→ms, universal-vs-static stream URL selection per browser codec support, codec display map, thumb fallbacks |

These target the code the README calls out as the riskiest to change (the player and the API layer), so future work — gapless playback, API optimisations — has a safety net.

**3. GitHub Actions CI** (`.github/workflows/ci.yml`)

Runs the exact checks husky runs locally — knip, eslint, prettier, typecheck, unit tests — plus a production build, on every PR and on pushes to `develop`/`staging`/`production`, across Node 20/22/24. No secrets required (e2e/Playwright intentionally excluded since it needs authenticated servers and snapshots).

## Possible pre-existing bugs noticed while writing tests

Not fixed here (this PR deliberately touches no production source); the tests pin the current behaviour so any future fix will show up as an intentional test change:

- `models.player.js` `playerLoadIndex`: when `playerX.loadTrack()` returns `false` (track failed to load) but `play` is true, `bridge.logPlaybackPlay()` and the Play analytics event still fire — playback is logged to the server for a track that never started.
- `jellyTranspose.js` `transposeLibraryArray`: returns `undefined` for missing input, while every other array transposer falls back to `[]`.
- `jellyTranspose.js` track links: missing artist/album ids interpolate literally (e.g. `/libraries/1/artists/null`) rather than being omitted.

Happy to follow up with a small fix PR for any of these if you agree they're bugs.

## Conventions

Follows `.github/copilot-instructions.md`: colocated `.test.ts` files, fixtures in colocated `__fixtures__/`, vitest globals, existing describe/test naming. In the spirit of the README's AI-transparency section: these tests were written with Claude Code and are headed `// Generated using Claude Code`, mirroring the existing `// Generated using GitHub Copilot` convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
