### PR TITLE
Add Apple AirPlay support (Webkit only)

### DIFF
--- a/__mocks__/HTMLAudioElement.ts
+++ b/__mocks__/HTMLAudioElement.ts
@@ -41,6 +41,10 @@ export class MockHTMLAudioElement {
     return Promise.resolve();
   }
 
+  setAttribute(_name: string, _value: string) {
+    // no-op — attribute setting not needed in tests
+  }
+
   pause() {
     this.paused = true;
   }

--- a/src/js/components/ControlBar/ControlBar.jsx
+++ b/src/js/components/ControlBar/ControlBar.jsx
@@ -8,7 +8,7 @@ import { NavLink } from 'react-router-dom';
 import clsx from 'clsx';
 
 import { Favourite, Icon, PopoverMenu, RangeSlider, StarRating } from 'js/components';
-import { useKeyPlaybackControls, useKeyMediaControls, useMediaMeta, usePlayerProgress } from 'js/hooks';
+import { useAirPlay, useKeyPlaybackControls, useKeyMediaControls, useMediaMeta, usePlayerProgress } from 'js/hooks';
 import { analyticsEvent, durationToStringShort } from 'js/utils';
 import platformFeatures from 'js/_config/platformFeatures';
 
@@ -224,6 +224,7 @@ export const SecondaryControls = ({ fullPageMode }) => {
 
   const controlBarFullPageToggle = useSelector(({ sessionModel }) => sessionModel.controlBarFullPageToggle);
   const controlBarQueueToggle = useSelector(({ sessionModel }) => sessionModel.controlBarQueueToggle);
+  const controlBarAirPlayToggle = useSelector(({ sessionModel }) => sessionModel.controlBarAirPlayToggle);
   const controlBarVolumeToggle = useSelector(({ sessionModel }) => sessionModel.controlBarVolumeToggle);
   const controlBarVolumeSlider = useSelector(({ sessionModel }) => sessionModel.controlBarVolumeSlider);
 
@@ -232,6 +233,8 @@ export const SecondaryControls = ({ fullPageMode }) => {
   const queueDisabled = !trackCurrent && !queueIsVisible ? true : false;
 
   const volIcon = volumeMuted || volumeLevel <= 0 ? 'VolXIcon' : volumeLevel < 50 ? 'VolLowIcon' : 'VolHighIcon';
+
+  const { isAvailable: airPlayAvailable, showPicker: showAirPlay } = useAirPlay();
 
   return (
     <div className={clsx(style.secondaryControls, { [style.fullPageMode]: fullPageMode })}>
@@ -263,6 +266,12 @@ export const SecondaryControls = ({ fullPageMode }) => {
             disabled={queueDisabled}
           >
             <Icon icon="QueueIcon" cover stroke />
+          </button>
+        )}
+
+        {airPlayAvailable && controlBarAirPlayToggle && (
+          <button type="button" className={style.airplay} onClick={showAirPlay} title="AirPlay">
+            <Icon icon="AirPlayIcon" cover stroke />
           </button>
         )}
 

--- a/src/js/components/ControlBar/ControlBar.module.scss
+++ b/src/js/components/ControlBar/ControlBar.module.scss
@@ -174,6 +174,7 @@ button.repeat,
 button.rewind,
 button.shuffle,
 button.volume,
+button.airplay,
 span.settings,
 .offline {
   display: block;

--- a/src/js/components/Icon/Icon.jsx
+++ b/src/js/components/Icon/Icon.jsx
@@ -8,6 +8,7 @@ import style from './Icon.module.scss';
 
 // General Icons
 import AccessibilityIcon from './icons/general-compressed/accessibility.svg?react';
+import AirPlayIcon from './icons/general-original/airplay.svg?react'; // [NOTE] use original — no compressed version yet
 import AlbumCollectionsIcon from './icons/general-compressed/album-collections.svg?react';
 import AlbumGenresIcon from './icons/general-compressed/album-genres.svg?react';
 import AlbumMoodsIcon from './icons/general-compressed/album-moods.svg?react';
@@ -130,6 +131,7 @@ import WindowsSiteIcon from './icons/site-compressed/windows.svg?react';
 // react-doctor-disable-next-line react-doctor/only-export-components
 export const generalIcons = {
   AccessibilityIcon,
+  AirPlayIcon,
   AlbumCollectionsIcon,
   AlbumGenresIcon,
   AlbumMoodsIcon,

--- a/src/js/components/Icon/icons/general-original/airplay.svg
+++ b/src/js/components/Icon/icons/general-original/airplay.svg
@@ -1,0 +1,4 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="1.5" y="1" width="15" height="11" rx="1.5" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke"/>
+<path d="M5.5 17L9 12L12.5 17H5.5Z" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke"/>
+</svg>

--- a/src/js/components/SettingsControls/SettingsControls.jsx
+++ b/src/js/components/SettingsControls/SettingsControls.jsx
@@ -76,6 +76,7 @@ const NowPlayingSettings = ({ platformOpts }) => {
 const SecondarySettings = ({ platformOpts }) => {
   const controlBarFullPageToggle = useSelector(({ sessionModel }) => sessionModel.controlBarFullPageToggle);
   const controlBarQueueToggle = useSelector(({ sessionModel }) => sessionModel.controlBarQueueToggle);
+  const controlBarAirPlayToggle = useSelector(({ sessionModel }) => sessionModel.controlBarAirPlayToggle);
   const controlBarVolumeToggle = useSelector(({ sessionModel }) => sessionModel.controlBarVolumeToggle);
   const controlBarVolumeSlider = useSelector(({ sessionModel }) => sessionModel.controlBarVolumeSlider);
 
@@ -89,6 +90,11 @@ const SecondarySettings = ({ platformOpts }) => {
       key: 'controlBarQueueToggle',
       label: 'Queue toggle',
       state: controlBarQueueToggle,
+    },
+    {
+      key: 'controlBarAirPlayToggle',
+      label: 'AirPlay toggle',
+      state: controlBarAirPlayToggle,
     },
     {
       key: 'controlBarVolumeToggle',

--- a/src/js/hooks/index.js
+++ b/src/js/hooks/index.js
@@ -1,3 +1,4 @@
+export { default as useAirPlay } from './useAirPlay';
 export { default as useColorTheme } from './useColorTheme';
 export { default as useElectronStatus } from './useElectronStatus';
 export { default as useGetAlbumDetail } from './useGetAlbumDetail';

--- a/src/js/hooks/useAirPlay.ts
+++ b/src/js/hooks/useAirPlay.ts
@@ -1,0 +1,25 @@
+// ======================================================================
+// IMPORTS
+// ======================================================================
+
+import { useEffect, useState } from 'react';
+import * as playerX from 'js/services/player';
+
+// ======================================================================
+// HOOK
+// ======================================================================
+
+const useAirPlay = () => {
+  const [isAvailable, setIsAvailable] = useState(false);
+
+  useEffect(() => {
+    playerX.subscribeAirPlayAvailability(setIsAvailable);
+    return () => {
+      playerX.unsubscribeAirPlayAvailability(setIsAvailable);
+    };
+  }, []);
+
+  return { isAvailable, showPicker: playerX.showAirPlayPicker };
+};
+
+export default useAirPlay;

--- a/src/js/services/player.native.ts
+++ b/src/js/services/player.native.ts
@@ -16,6 +16,9 @@ let isResetting = false;
 // Guards unload() from doing unnecessary work when the player is already idle.
 let needsReinit = true;
 
+const airPlayCallbacks = new Set<(available: boolean) => void>();
+let airPlayAvailable = false;
+
 // ======================================================================
 // INITIALISE
 // ======================================================================
@@ -33,6 +36,11 @@ export const init = ({
     playerElement = document.createElement('audio');
     playerElement.pause();
     playerElement.volume = volumeMuted ? 0 : volumeLevel / 100;
+    playerElement.setAttribute('x-webkit-airplay', 'allow');
+    playerElement.addEventListener('webkitplaybacktargetavailabilitychanged', (event: Event) => {
+      airPlayAvailable = (event as any).availability === 'available';
+      airPlayCallbacks.forEach((cb) => cb(airPlayAvailable));
+    });
     playerElement.addEventListener('loadstart', () => {
       // New source is loading — clear the flag so subsequent errors are real.
       isResetting = false;
@@ -157,3 +165,20 @@ export const getCurrentProgress = (): number => {
 // export const clearNextTrack = (): void => {
 //   return;
 // };
+
+// ======================================================================
+// AIRPLAY
+// ======================================================================
+
+export const showAirPlayPicker = (): void => {
+  (playerElement as any)?.webkitShowPlaybackTargetPicker?.();
+};
+
+export const subscribeAirPlayAvailability = (cb: (available: boolean) => void): void => {
+  airPlayCallbacks.add(cb);
+  cb(airPlayAvailable); // replay current state immediately
+};
+
+export const unsubscribeAirPlayAvailability = (cb: (available: boolean) => void): void => {
+  airPlayCallbacks.delete(cb);
+};

--- a/src/js/services/player.ts
+++ b/src/js/services/player.ts
@@ -164,6 +164,14 @@ export const setVolume = (volumeLevel: number): void => {
 };
 
 // ======================================================================
+// AIRPLAY
+// ======================================================================
+
+export const showAirPlayPicker = (): void => nativeX.showAirPlayPicker();
+export const subscribeAirPlayAvailability = nativeX.subscribeAirPlayAvailability;
+export const unsubscribeAirPlayAvailability = nativeX.unsubscribeAirPlayAvailability;
+
+// ======================================================================
 // PRELOADING STUBS
 // [NOTE] Not currently used, but may be in future
 // ======================================================================

--- a/src/js/store/models.session.js
+++ b/src/js/store/models.session.js
@@ -128,6 +128,7 @@ const sessionState = {
 
   controlBarFullPageToggle: true,
   controlBarQueueToggle: true,
+  controlBarAirPlayToggle: true,
   controlBarVolumeToggle: true,
   controlBarVolumeSlider: true,
 


### PR DESCRIPTION
Adds Apple Airplay support via native webkit audio element.

- Detect AirPlay availability via webkitplaybacktargetavailabilitychanged on the audio element
- Add AirPlay button to control bar secondary controls (before volume) in both main and full screen view
- Add global AirPlay toggle to Settings > Controls

I also put together a Tauri build of the app to allow a desktop experience with webkit. Can see that in my repos if you are interested.